### PR TITLE
BT-4396 Encoding of Fauna Models

### DIFF
--- a/faunaJava/src/main/java/com/fauna/encoding/DocumentReferenceWrapper.java
+++ b/faunaJava/src/main/java/com/fauna/encoding/DocumentReferenceWrapper.java
@@ -1,0 +1,46 @@
+package com.fauna.encoding;
+
+import com.fauna.query.model.DocumentReference;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Wraps a Fauna document reference for serialization with GSON.
+ * This class is a utility to convert {@link DocumentReference} instances into the JSON format
+ * used by Fauna to denote references, with specific structure dictated by the database's
+ * requirements for references.
+ */
+class DocumentReferenceWrapper {
+
+    /**
+     * A map representing the structure of a Fauna reference.
+     * The map is serialized into a JSON object with the key "@ref" to conform with
+     * the JSON format that Fauna expects for document references.
+     */
+    @SerializedName("@ref")
+    private final Map<String, Object> ref;
+
+    /**
+     * Constructs a new {@code DocumentReferenceWrapper} with the specified {@link DocumentReference}.
+     * It initializes an internal map structure to hold and represent the reference in the way
+     * Fauna can interpret.
+     *
+     * @param documentReference The document reference to wrap. This object must contain the ID
+     *                          and the collection module information to construct a valid reference.
+     *                          It should not be {@code null}.
+     * @throws NullPointerException If {@code documentReference} or any required property of it is {@code null}.
+     */
+    public DocumentReferenceWrapper(DocumentReference documentReference) {
+        if (documentReference == null) {
+            throw new NullPointerException("DocumentReference cannot be null.");
+        }
+
+        // Initialize the reference map with the document's ID and collection information.
+        this.ref = new HashMap<>();
+        this.ref.put("id", documentReference.getId());
+        this.ref.put("coll", new ModuleWrapper(documentReference.getColl()));
+    }
+
+}

--- a/faunaJava/src/main/java/com/fauna/encoding/FaunaEncoder.java
+++ b/faunaJava/src/main/java/com/fauna/encoding/FaunaEncoder.java
@@ -1,6 +1,12 @@
 package com.fauna.encoding;
 
 import com.fauna.exception.TypeError;
+import com.fauna.query.model.Document;
+import com.fauna.query.model.DocumentReference;
+import com.fauna.query.model.Module;
+import com.fauna.query.model.NamedDocument;
+import com.fauna.query.model.NamedDocumentReference;
+import com.fauna.query.model.NullDocument;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -20,6 +26,10 @@ import java.time.LocalDateTime;
  *     <li>{@code LocalDateTime} values to {@code @time} for Fauna.</li>
  *     <li>{@code LocalDate} values to {@code @date} for Fauna.</li>
  *     <li>{@code Boolean} values {@code true} and {@code false} are preserved as is for Fauna.</li>
+ *     <li>{@code null} values are preserved as {@code None} for Fauna.</li>
+ *     <li>{@code Document} instances to {@code @ref} for Fauna.</li>
+ *     <li>{@code DocumentReference} instances to {@code @ref} for Fauna.</li>
+ *     <li>{@code Module} instances to {@code @mod} for Fauna.</li>
  * </ul>
  * <p>
  * This class ensures that data types are encoded properly to maintain the integrity of the data when interacting with the Fauna service.
@@ -37,6 +47,7 @@ public class FaunaEncoder {
      *
      * @param value The object to encode.
      * @return A string containing the JSON encoded representation of the value.
+     * @throws TypeError if the object type is not supported by the encoder.
      */
     public static String encode(Object value) {
         return gson.toJson(wrapValue(value));
@@ -68,6 +79,28 @@ public class FaunaEncoder {
         }
         if (value instanceof LocalDate) {
             return new DateWrapper((LocalDate) value);
+        }
+        if (value instanceof DocumentReference) {
+            return new DocumentReferenceWrapper((DocumentReference) value);
+        }
+        if (value instanceof NamedDocumentReference) {
+            return new NamedDocumentReferenceWrapper((NamedDocumentReference) value);
+        }
+        if (value instanceof Module) {
+            return new ModuleWrapper((Module) value);
+        }
+        if (value instanceof NullDocument) {
+            return new NullDocumentWrapper((NullDocument) value);
+        }
+        if (value instanceof Document) {
+            return new DocumentReferenceWrapper(
+                    new DocumentReference(((Document) value).getColl(), ((Document) value).getId())
+            );
+        }
+        if (value instanceof NamedDocument) {
+            return new NamedDocumentReferenceWrapper(
+                    new NamedDocumentReference(((NamedDocument) value).getColl(), ((NamedDocument) value).getName())
+            );
         }
         throw new TypeError("Unsupported type: " + value.getClass().getName());
     }

--- a/faunaJava/src/main/java/com/fauna/encoding/ModuleWrapper.java
+++ b/faunaJava/src/main/java/com/fauna/encoding/ModuleWrapper.java
@@ -1,0 +1,35 @@
+package com.fauna.encoding;
+
+import com.fauna.query.model.Module;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Wraps a module object for JSON serialization with GSON. This class specifically handles
+ * the serialization of {@link Module} instances to conform with the JSON structure expected by
+ * Fauna. The serialization process will output a JSON object with a single key "@mod" that
+ * maps to the name of the module.
+ */
+class ModuleWrapper {
+
+    /**
+     * The name of the module represented as a string. The {@link SerializedName} annotation
+     * specifies the key "@mod" under which this value will be placed in the serialized JSON object.
+     */
+    @SerializedName("@mod")
+    private final String name;
+
+    /**
+     * Constructs a {@code ModuleWrapper} with the provided {@link Module} object.
+     * It extracts the name of the module and prepares it for serialization with the "@mod" key.
+     *
+     * @param module The {@link Module} instance to wrap. The module name is extracted and stored.
+     *               Must not be {@code null} to avoid a {@link NullPointerException}.
+     * @throws NullPointerException If the {@code module} parameter is {@code null}.
+     */
+    ModuleWrapper(Module module) {
+        if (module == null) {
+            throw new NullPointerException("Module cannot be null for ModuleWrapper.");
+        }
+        this.name = module.getName();
+    }
+}

--- a/faunaJava/src/main/java/com/fauna/encoding/NamedDocumentReferenceWrapper.java
+++ b/faunaJava/src/main/java/com/fauna/encoding/NamedDocumentReferenceWrapper.java
@@ -1,0 +1,46 @@
+package com.fauna.encoding;
+
+import com.fauna.query.model.NamedDocumentReference;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A wrapper class that prepares a {@link NamedDocumentReference} for JSON serialization with GSON,
+ * formatting it according to Fauna's reference object structure. This class specifically handles
+ * the inclusion of the document's name and its collection module within a serialized reference map.
+ */
+class NamedDocumentReferenceWrapper {
+
+    /**
+     * A map that holds the structure of a named document reference as expected by Fauna when serialized.
+     * The serialized name and collection information are encapsulated within this map with the "@ref"
+     * key annotation provided by the {@link SerializedName} annotation.
+     */
+    @SerializedName("@ref")
+    private final Map<String, Object> reference;
+
+    /**
+     * Constructs a new {@code NamedDocumentReferenceWrapper} with the provided {@link NamedDocumentReference}.
+     * This constructor initializes a map with "name" and "coll" keys to represent the document reference
+     * as required by Fauna's JSON format for named references.
+     *
+     * @param namedDocumentReference The named document reference to wrap, not to be {@code null}.
+     *                               It should contain both the name of the document and the collection
+     *                               module reference.
+     * @throws NullPointerException If the input {@code namedDocumentReference} or any of its required
+     *                              properties are {@code null}.
+     */
+    public NamedDocumentReferenceWrapper(NamedDocumentReference namedDocumentReference) {
+        if (namedDocumentReference == null) {
+            throw new NullPointerException("NamedDocumentReference cannot be null.");
+        }
+        // Initialize the map to be used for serialization with appropriate keys and values.
+        Map<String, Object> details = new HashMap<>();
+        details.put("name", namedDocumentReference.getName());
+        details.put("coll", new ModuleWrapper(namedDocumentReference.getColl()));
+        this.reference = details;
+    }
+}
+

--- a/faunaJava/src/main/java/com/fauna/encoding/NullDocumentWrapper.java
+++ b/faunaJava/src/main/java/com/fauna/encoding/NullDocumentWrapper.java
@@ -1,0 +1,56 @@
+package com.fauna.encoding;
+
+import com.fauna.query.model.BaseReference;
+import com.fauna.query.model.DocumentReference;
+import com.fauna.query.model.NamedDocumentReference;
+import com.fauna.query.model.NullDocument;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A wrapper class for serializing {@code NullDocument} instances in the structure expected by Fauna.
+ * This class adapts the {@code NullDocument} to a JSON-serializable format by converting its reference
+ * information into a map structure. The resulting JSON object uses the "@ref" key to denote the reference
+ * type according to Fauna's schema.
+ */
+class NullDocumentWrapper {
+
+    /**
+     * A map representing the reference details of a {@code NullDocument}.
+     * The map is structured with keys that Fauna understands for representing document references.
+     */
+    @SerializedName("@ref")
+    private final Map<String, Object> refMap;
+
+    /**
+     * Constructs a new {@code NullDocumentWrapper} with the specified {@code NullDocument}.
+     * Depending on the subtype of the {@code BaseReference} held by the {@code NullDocument},
+     * it prepares a map with either "id" and "coll" keys for a {@code DocumentReference} or "name"
+     * and "coll" for a {@code NamedDocumentReference}.
+     *
+     * @param nullDoc The {@code NullDocument} to wrap. Its reference should be a valid {@code BaseReference}
+     *                instance, either {@code DocumentReference} or {@code NamedDocumentReference}.
+     *                The reference is used to populate the map with appropriate details.
+     */
+    public NullDocumentWrapper(NullDocument nullDoc) {
+        this.refMap = new HashMap<>();
+        BaseReference ref = nullDoc.getRef();
+
+        // Check the type of reference and populate the map accordingly.
+        if (ref instanceof DocumentReference docRef) {
+            Map<String, Object> collMap = new HashMap<>();
+            collMap.put("@mod", docRef.getColl().getName());
+            refMap.put("id", docRef.getId());
+            refMap.put("coll", collMap);
+        } else if (ref instanceof NamedDocumentReference namedDocRef) {
+            Map<String, Object> collMap = new HashMap<>();
+            collMap.put("@mod", namedDocRef.getColl().getName());
+            refMap.put("name", namedDocRef.getName());
+            refMap.put("coll", collMap);
+        }
+
+    }
+
+}

--- a/faunaJava/src/test/java/com/fauna/encoding/FaunaEncoderTest.java
+++ b/faunaJava/src/test/java/com/fauna/encoding/FaunaEncoderTest.java
@@ -1,5 +1,11 @@
 package com.fauna.encoding;
 
+import com.fauna.query.model.Document;
+import com.fauna.query.model.DocumentReference;
+import com.fauna.query.model.Module;
+import com.fauna.query.model.NamedDocument;
+import com.fauna.query.model.NamedDocumentReference;
+import com.fauna.query.model.NullDocument;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
@@ -164,6 +170,89 @@ class FaunaEncoderTest {
         LocalDate testDate = LocalDate.parse("2023-03-17");
 
         String encoded = FaunaEncoder.encode(testDate);
+        JsonElement actualJson = JsonParser.parseString(encoded);
+
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    void testEncodeDocumentReference() {
+        JsonElement expectedJson = JsonParser.parseString("{'@ref': {'coll': {'@mod': 'Col'}, 'id': \"123\"}}");
+        DocumentReference docRef = new DocumentReference(new Module("Col"), "123");
+
+        String encoded = FaunaEncoder.encode(docRef);
+        JsonElement actualJson = JsonParser.parseString(encoded);
+
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    void testEncodeNullDocument() {
+        JsonElement expectedJson = JsonParser.parseString("{\"@ref\": {\"id\": \"456\", \"coll\": {\"@mod\": \"NDCol\"}}}");
+        NullDocument nullDoc = new NullDocument(new DocumentReference(new Module("NDCol"), "456"), "not found");
+
+        String encoded = FaunaEncoder.encode(nullDoc);
+        JsonElement actualJson = JsonParser.parseString(encoded);
+
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    void testEncodeNamedNullDocument() {
+        JsonElement expectedJson = JsonParser.parseString("{\"@ref\": {\"name\": \"Party\", \"coll\": {\"@mod\": \"Collection\"}}}");
+        NullDocument nullDoc = new NullDocument(new NamedDocumentReference("Collection", "Party"), "not found");
+
+        String encoded = FaunaEncoder.encode(nullDoc);
+        JsonElement actualJson = JsonParser.parseString(encoded);
+
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void testEncodeNamedDocumentReference() {
+        JsonElement expectedJson = JsonParser.parseString("{\"@ref\": {\"name\": \"Hi\", \"coll\": {\"@mod\": \"Col\"}}}");
+        NamedDocumentReference docRef = new NamedDocumentReference("Col", "Hi");
+
+        String encoded = FaunaEncoder.encode(docRef);
+        JsonElement actualJson = JsonParser.parseString(encoded);
+
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void testEncodeDocument() {
+        JsonElement expectedJson = JsonParser.parseString("{\"@ref\": {\"id\": \"123\", \"coll\": {\"@mod\": \"Dogs\"}}}");
+
+        LocalDateTime fixedDatetime = LocalDateTime.now();
+        Module dogsModule = new Module("Dogs");
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "Scout");
+        Document testDoc = new Document("123", fixedDatetime, dogsModule, data);
+
+        String encoded = FaunaEncoder.encode(testDoc);
+        JsonElement actualJson = JsonParser.parseString(encoded);
+
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void testEncodeNamedDocuments() {
+        JsonElement expectedJson = JsonParser.parseString("{\"@ref\": {\"name\": \"DogSchema\", \"coll\": {\"@mod\": \"Dogs\"}}}");
+        LocalDateTime fixedDatetime = LocalDateTime.now();
+        NamedDocument testNamedDoc = new NamedDocument("DogSchema", fixedDatetime, new Module("Dogs"), new HashMap<>());
+
+        String encoded = FaunaEncoder.encode(testNamedDoc);
+        JsonElement actualJson = JsonParser.parseString(encoded);
+
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void testEncodeModule() {
+        JsonElement expectedJson = JsonParser.parseString("{\"@mod\": \"Math\"}");
+        Module testModule = new Module("Math");
+
+        String encoded = FaunaEncoder.encode(testModule);
         JsonElement actualJson = JsonParser.parseString(encoded);
 
         assertEquals(expectedJson, actualJson);


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-4329

Java objects needed a way to be serialized into JSON that conforms to the Fauna database's reference structure

Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change.

## Solution
DocumentReferenceWrapper, ModuleWrapper, NamedDocumentReferenceWrapper, and NullDocumentWrapper classes were created to encapsulate the reference structure required by Fauna for different object types.
The FaunaEncoder class was updated to handle the conversion of various data types

## Result

The new wrapper classes allowed for proper serialization of Fauna database references into JSON, meeting the structure requirements of Fauna's API.
The FaunaEncoder.encode method was enhanced to support a broader range of object types, ensuring that all Fauna data types could be converted to their JSON 

## Testing

The FaunaEncoderTest class included tests to verify that the encoding process produced the correct JSON output for various object types, such as DocumentReference, NullDocument, NamedDocumentReference, Document, NamedDocument, and Module.
Each test case checked the JSON result against an expected string to ensure that the serialization was performed correctly.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
