### PR TITLE
[BT-4418] Add TokenType enum for Fauna serialization

### DIFF
--- a/common/src/main/java/com/fauna/common/enums/FaunaTokenType.java
+++ b/common/src/main/java/com/fauna/common/enums/FaunaTokenType.java
@@ -3,10 +3,11 @@ package com.fauna.common.enums;
 /**
  * Enumeration representing token types for Fauna serialization.
  */
-public enum TokenType {
+public enum FaunaTokenType {
     NONE,
 
     START_OBJECT,
+    START_ESCAPED_OBJECT,
     END_OBJECT,
 
     START_ARRAY,
@@ -37,5 +38,7 @@ public enum TokenType {
 
     NULL,
 
-    MODULE
+    MODULE,
+    END_SET,
+    START_SET
 }


### PR DESCRIPTION
Ticket(s): BT-4418

## Problem

Our project lacks an enum representing token types for Fauna serialization. This absence makes it harder to manage and understand the serialization logic.

## Solution

Added a `FaunaTokenType` enum to represent various token types used in Fauna serialization. The enum follows Java naming conventions and is placed in the 'enums' package within the project.

- `FaunaTokenType` enum contains different token types used during serialization.
- The enum is organized following the Java naming conventions.
- Placed in the 'enums' package.

## Result

The addition of the `FaunaTokenType` enum provides a clear and standardized way to handle different token types during Fauna serialization.

## Testing

Manually verified the enum structure and ensured it follows Java conventions.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
