### PR TITLE
[BT-4418] FaunaParserTest increase coverage

### DIFF
--- a/faunaJava/src/main/java/com/fauna/serialization/FaunaParser.java
+++ b/faunaJava/src/main/java/com/fauna/serialization/FaunaParser.java
@@ -71,28 +71,7 @@ public class FaunaParser {
         END_REF,
         END_ARRAY
     ));
-
-    public void skip() throws IOException {
-        switch (getCurrentTokenType()) {
-            case START_OBJECT:
-            case START_ARRAY:
-            case START_PAGE:
-            case START_REF:
-            case START_DOCUMENT:
-                skipInternal();
-                break;
-        }
-    }
-
-    private void skipInternal() throws IOException {
-        int startCount = tokenStack.size();
-        while (read()) {
-            if (tokenStack.size() < startCount) {
-                break;
-            }
-        }
-    }
-
+    
     public boolean read() throws IOException {
         taggedTokenValue = null;
 

--- a/faunaJava/src/test/java/com/fauna/serialization/FaunaParserTest.java
+++ b/faunaJava/src/test/java/com/fauna/serialization/FaunaParserTest.java
@@ -438,7 +438,7 @@ class FaunaParserTest {
             new AbstractMap.SimpleEntry<>(FaunaTokenType.END_OBJECT, null)
         );
 
-        assertReader(reader, expectedTokens, false);
+        assertReader(reader, expectedTokens);
     }
 
     @Test
@@ -499,7 +499,7 @@ class FaunaParserTest {
             new AbstractMap.SimpleEntry<>(FaunaTokenType.END_ARRAY, null)
         );
 
-        assertReader(reader, expectedTokens, false);
+        assertReader(reader, expectedTokens);
     }
 
     @Test
@@ -510,76 +510,6 @@ class FaunaParserTest {
             reader.read();
             reader.read();
         }, "Failed to advance underlying JSON reader.");
-    }
-
-    @Test
-    public void skipValues() throws IOException {
-        List<String> tests = List.of(
-            "{\"k1\": {}, \"k2\": {}}",
-            "[\"k1\",[],{}]",
-            "{\"@ref\": {}}",
-            "{\"@doc\": {}}",
-            "{\"@set\": {}}",
-            "{\"@object\":{}}"
-        );
-
-        for (String test : tests) {
-            FaunaParser reader = new FaunaParser(new ByteArrayInputStream(test.getBytes()));
-            reader.read();
-            reader.skip();
-            assertFalse(reader.read());
-        }
-    }
-
-    @Test
-    public void skipNestedEscapedObject() throws IOException {
-        String test = "{\"@object\": {\"inner\": {\"@object\": {\"foo\": \"bar\"}}, \"k2\": {}}}";
-        FaunaParser reader = new FaunaParser(new ByteArrayInputStream(test.getBytes()));
-        reader.read(); // {"@object":{
-        assertEquals(FaunaTokenType.START_OBJECT, reader.getCurrentTokenType());
-        reader.read(); // inner
-        assertEquals(FaunaTokenType.FIELD_NAME, reader.getCurrentTokenType());
-        reader.read(); // {"@object":{
-        assertEquals(FaunaTokenType.START_OBJECT, reader.getCurrentTokenType());
-        reader.skip(); // "foo": "bar"}}
-        assertEquals(FaunaTokenType.END_OBJECT, reader.getCurrentTokenType());
-        reader.read();
-        assertEquals(FaunaTokenType.FIELD_NAME, reader.getCurrentTokenType());
-        assertEquals("k2", reader.getValueAsString());
-    }
-
-    @Test
-    public void skipNestedObject() throws IOException {
-        String test = "{\"k\":{\"inner\":{}},\"k2\":{}}";
-        FaunaParser reader = new FaunaParser(new ByteArrayInputStream(test.getBytes()));
-        reader.read(); // {
-        assertEquals(FaunaTokenType.START_OBJECT, reader.getCurrentTokenType());
-        reader.read(); // k
-        assertEquals(FaunaTokenType.FIELD_NAME, reader.getCurrentTokenType());
-        reader.read(); // {
-        assertEquals(FaunaTokenType.START_OBJECT, reader.getCurrentTokenType());
-        reader.skip(); // "inner":{}}
-        assertEquals(FaunaTokenType.END_OBJECT, reader.getCurrentTokenType());
-        reader.read();
-        assertEquals(FaunaTokenType.FIELD_NAME, reader.getCurrentTokenType());
-        assertEquals("k2", reader.getValueAsString());
-    }
-
-    @Test
-    public void skipNestedArrays() throws IOException {
-        String test = "{\"k\":[\"1\",\"2\"],\"k2\":{}}";
-        FaunaParser reader = new FaunaParser(new ByteArrayInputStream(test.getBytes()));
-        reader.read(); // {
-        assertEquals(FaunaTokenType.START_OBJECT, reader.getCurrentTokenType());
-        reader.read(); // k
-        assertEquals(FaunaTokenType.FIELD_NAME, reader.getCurrentTokenType());
-        reader.read(); // [
-        assertEquals(FaunaTokenType.START_ARRAY, reader.getCurrentTokenType());
-        reader.skip(); // "1","2"]
-        assertEquals(FaunaTokenType.END_ARRAY, reader.getCurrentTokenType());
-        reader.read();
-        assertEquals(FaunaTokenType.FIELD_NAME, reader.getCurrentTokenType());
-        assertEquals("k2", reader.getValueAsString());
     }
 
     private static void assertReader(FaunaParser reader,


### PR DESCRIPTION
Ticket(s): BT-4418

## Problem

The current Fauna serialization module lacks a better test coverage.

## Solution

 Improve unit test coverage.

## Result

Increase unit test coverage.

## Testing

Run `FaunaParserTest.java`


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
