### PR TITLE
[BT-4418] FaunaParser add skip()

### DIFF
--- a/faunaJava/src/main/java/com/fauna/serialization/FaunaParser.java
+++ b/faunaJava/src/main/java/com/fauna/serialization/FaunaParser.java
@@ -71,7 +71,28 @@ public class FaunaParser {
         END_REF,
         END_ARRAY
     ));
-    
+
+    public void skip() throws IOException {
+        switch (getCurrentTokenType()) {
+            case START_OBJECT:
+            case START_ARRAY:
+            case START_PAGE:
+            case START_REF:
+            case START_DOCUMENT:
+                skipInternal();
+                break;
+        }
+    }
+
+    private void skipInternal() throws IOException {
+        int startCount = tokenStack.size();
+        while (read()) {
+            if (tokenStack.size() < startCount) {
+                break;
+            }
+        }
+    }
+
     public boolean read() throws IOException {
         taggedTokenValue = null;
 


### PR DESCRIPTION
Ticket(s): BT-4418

## Problem

The current Fauna serialization module lacks a dedicated method to skip values.

## Solution

 Implemented specific logic for handling Fauna-specific skip.

## Result

The addition of this capability enables the skip of tokens, enhancing the functionality of the Fauna serialization module.

## Testing

Run `FaunaParserTest.java`


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.