### PR TITLE
add snapshot suffix to version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.0
+version=0.1.0-SNAPSHOT
 junitVersion=5.10.0
 mockitoVersion=5.6.0
 jacksonVersion=2.15.3


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

publishing to maven central no longer allows snapshot builds, but regardless this will prevent us from publishing any artifacts before finalizing a release.