### PR TITLE
[DOCS-3128] Fix comments in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following application:
 
 * Initializes a client instance to connect to Fauna.
 * Composes a basic FQL query using an FQL template.
-* Runs the query using `query()`  and `asyncQuery()`.
+* Runs the query using `query()` and `asyncQuery()`.
 
 ```java
 package org.example;


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): [DOCS-3128](https://faunadb.atlassian.net/browse/DOCS-3128)

## Problem

The main README example contains:

- Copy/paste errors (`[QueryResponse](src/main/java/com/fauna/response/QueryResponse.java).`)
- Grammar errors
- Redundant comments

I introduced these in https://github.com/fauna/fauna-jvm/pull/62.

## Solution

Fixes the above errors. Also fixes a few other misc errors.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[DOCS-3128]: https://faunadb.atlassian.net/browse/DOCS-3128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ