### PR TITLE
Add support for ser/deser of optionals

### DIFF
--- a/src/main/java/com/fauna/serialization/Deserializer.java
+++ b/src/main/java/com/fauna/serialization/Deserializer.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Represents methods for deserializing objects to and from Fauna's value format.
@@ -159,6 +160,13 @@ public class Deserializer {
                 } else if (rawType == Page.class) {
                     return (IDeserializer<T>) new PageDeserializer<>(elemDeserializer);
                 }
+            }
+
+            if (rawType == Optional.class) {
+                Type[] typeArgs = parameterizedType.getActualTypeArguments();
+                Type elemType = typeArgs[0];
+                IDeserializer<?> elemDeserializer = generate(context, elemType);
+                return (IDeserializer<T>) new OptionalDeserializer<>(elemDeserializer);
             }
         } else if (type instanceof Class<?> && !DESERIALIZERS.containsKey(type)
             && context != null) {

--- a/src/main/java/com/fauna/serialization/OptionalDeserializer.java
+++ b/src/main/java/com/fauna/serialization/OptionalDeserializer.java
@@ -1,0 +1,28 @@
+package com.fauna.serialization;
+
+import com.fauna.enums.FaunaTokenType;
+import com.fauna.exception.ClientException;
+import com.fauna.interfaces.IDeserializer;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class OptionalDeserializer<T> extends BaseDeserializer<Optional<T>> {
+
+    private final IDeserializer<T> inner;
+
+    public OptionalDeserializer(IDeserializer<T> innerDeserializer) {
+        inner = innerDeserializer;
+    }
+
+    @Override
+    public Optional<T> doDeserialize(UTF8FaunaParser reader)
+        throws IOException {
+
+        if (reader.getCurrentTokenType() == FaunaTokenType.NULL) {
+            return Optional.empty();
+        }
+
+        return Optional.of(inner.deserialize(reader));
+    }
+}

--- a/src/main/java/com/fauna/serialization/Serializer.java
+++ b/src/main/java/com/fauna/serialization/Serializer.java
@@ -14,11 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class Serializer {
 
@@ -143,6 +139,13 @@ public class Serializer {
                 serialize(writer, item, null);
             }
             writer.writeEndArray();
+        } else if (obj instanceof Optional) {
+            var opt = ((Optional<?>) obj);
+            if (opt.isEmpty()) {
+                writer.writeNullValue();
+            } else {
+                serialize(writer, opt.get(), null);
+            }
         } else {
             serializeClassInternal(writer, obj, context);
         }

--- a/src/main/java/com/fauna/serialization/generic/OptionalOf.java
+++ b/src/main/java/com/fauna/serialization/generic/OptionalOf.java
@@ -1,0 +1,33 @@
+package com.fauna.serialization.generic;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+
+/**
+ * OptionalOf stores the generic parameter class to evade type erasure during deserialization.
+ * @param <E> The element class of the list.
+ */
+public class OptionalOf<E> implements ParameterizedOf<Optional<E>> {
+
+    private final Class<E> clazz;
+
+    public OptionalOf(Class<E> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+        return new Type[]{clazz};
+    }
+
+    @Override
+    public Type getRawType() {
+        return Optional.class;
+    }
+
+    @Override
+    public Type getOwnerType() {
+        return null;
+    }
+}

--- a/src/main/java/com/fauna/serialization/generic/Parameterized.java
+++ b/src/main/java/com/fauna/serialization/generic/Parameterized.java
@@ -16,4 +16,8 @@ public class Parameterized {
     public static <T> PageOf<T> pageOf(Class<T> clazz) {
         return new PageOf<>(clazz);
     }
+
+    public static <T> OptionalOf<T> optionalOf(Class<T> clazz) {
+        return new OptionalOf<>(clazz);
+    }
 }

--- a/src/test/java/com/fauna/e2e/E2EQueryTest.java
+++ b/src/test/java/com/fauna/e2e/E2EQueryTest.java
@@ -9,12 +9,15 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static com.fauna.serialization.generic.Parameterized.listOf;
 import static com.fauna.serialization.generic.Parameterized.mapOf;
 import static com.fauna.serialization.generic.Parameterized.pageOf;
+import static com.fauna.serialization.generic.Parameterized.optionalOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class E2EQueryTest {
     public static final FaunaClient c = com.fauna.e2e.LocalFauna.get();
@@ -140,5 +143,32 @@ public class E2EQueryTest {
 
         assertEquals(2, actual.size());
         assertEquals("Alice", actual.get(0).getFirstName());
+    }
+
+    @Test
+    public void query_optionalNull() {
+        var empty = Optional.empty();
+        var q = Query.fql("${empty}", new HashMap<>(){{
+            put("empty", empty);
+        }});
+
+        var qs = c.query(q, optionalOf(int.class));
+        var actual = qs.getData();
+
+        assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    public void query_optionalNotNull() {
+        var val = Optional.of(42);
+        var q = Query.fql("${val}", new HashMap<>(){{
+            put("val", val);
+        }});
+
+        var qs = c.query(q, optionalOf(int.class));
+        var actual = qs.getData();
+
+        assertTrue(actual.isPresent());
+        assertEquals(42, actual.get());
     }
 }

--- a/src/test/java/com/fauna/serialization/SerializerTest.java
+++ b/src/test/java/com/fauna/serialization/SerializerTest.java
@@ -24,11 +24,7 @@ import com.fauna.exception.ClientException;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -39,26 +35,28 @@ class SerializerTest {
     public void serializeValues() throws IOException {
         Instant dt = Instant.parse("2024-01-23T13:33:10.300Z");
 
-        HashMap<String, Object> tests = new HashMap<>();
-        tests.put("\"hello\"", "hello");
-        tests.put("true", true);
-        tests.put("false", false);
-        tests.put("null", null);
-        tests.put("{\"@date\":\"2023-12-13\"}", LocalDate.of(2023, 12, 13));
-        tests.put("{\"@double\":\"1.2\"}", 1.2d);
-        tests.put("{\"@double\":\"1.340000033378601\"}", 1.34f);
-        tests.put("{\"@int\":\"1\"}", Byte.parseByte("1"));
-        tests.put("{\"@int\":\"2\"}", Byte.parseByte("2"));
-        tests.put("{\"@int\":\"40\"}", Short.parseShort("40"));
-        tests.put("{\"@int\":\"41\"}", Short.parseShort("41"));
-        tests.put("{\"@int\":\"42\"}", 42);
-        tests.put("{\"@long\":\"43\"}", 43L);
-        tests.put("{\"@mod\":\"module\"}", new Module("module"));
-        tests.put("{\"@time\":\"2024-01-23T13:33:10.300Z\"}", dt);
+        HashMap<Object, String> tests = new HashMap<>();
+        tests.put("hello", "\"hello\"");
+        tests.put(true, "true");
+        tests.put(false, "false");
+        tests.put(null, "null");
+        tests.put(LocalDate.of(2023, 12, 13), "{\"@date\":\"2023-12-13\"}");
+        tests.put(1.2d, "{\"@double\":\"1.2\"}");
+        tests.put(1.34f, "{\"@double\":\"1.340000033378601\"}");
+        tests.put(Byte.parseByte("1"), "{\"@int\":\"1\"}");
+        tests.put(Byte.parseByte("2"), "{\"@int\":\"2\"}");
+        tests.put(Short.parseShort("40"), "{\"@int\":\"40\"}");
+        tests.put(Short.parseShort("41"), "{\"@int\":\"41\"}");
+        tests.put(42, "{\"@int\":\"42\"}");
+        tests.put(42L, "{\"@long\":\"42\"}");
+        tests.put(new Module("module"), "{\"@mod\":\"module\"}");
+        tests.put(dt, "{\"@time\":\"2024-01-23T13:33:10.300Z\"}");
+        tests.put(Optional.of(42), "{\"@int\":\"42\"}");
+        tests.put(Optional.empty(), "null");
 
-        for (Map.Entry<String, Object> entry : tests.entrySet()) {
-            String expected = entry.getKey();
-            Object test = entry.getValue();
+        for (Map.Entry<Object, String> entry : tests.entrySet()) {
+            Object test = entry.getKey();
+            String expected = entry.getValue();
             String result = Serializer.serialize(test);
             assertEquals(expected, result);
         }


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): BT-5012

## Problem
We don't handle optionals on the way in or out.

## Solution

* Handle serialization of optionals
* Handle deserialization of optionals at the top level only (for now)

## Testing

Added tests


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
