### PR TITLE
[DOCS-3132] Remove erroneous README comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,14 +133,12 @@ public class App {
         // Use `query()` to run a synchronous query.
         // Synchronous queries block the current thread until the query completes.
         // Accepts the query, expected result class, and a nullable set of query options.
-        // Returns a `QueryResponse`.
         QuerySuccess<Page<Product>> result = client.query(query, new PageOf<>(Product.class));
         printResults(result.getData().data());
     }
 
     // Use `asyncQuery()` to run an asynchronous, non-blocking query.
     // Accepts the query, expected result class, and a nullable set of query options.
-    // Returns a `CompletableFuture<QueryResponse>`.
     private static void runAsynchronousQuery(FaunaClient client, Query query) throws ExecutionException, InterruptedException {
         CompletableFuture<QuerySuccess<Page<Product>>> futureResult = client.asyncQuery(query, new PageOf<>(Product.class));
 


### PR DESCRIPTION
<!-- Reminder: Keep READMEs up to date -->

Ticket(s): [DOCS-3132](https://faunadb.atlassian.net/browse/DOCS-3132)

## Problem/Solution

Removes an erroneous comment leftover from https://github.com/fauna/fauna-jvm/pull/74

This comment isn't needed as we now provide an explicit type.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[DOCS-3132]: https://faunadb.atlassian.net/browse/DOCS-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ