### PR TITLE
Decode abort data

### DIFF
--- a/src/main/java/com/fauna/exception/AbortException.java
+++ b/src/main/java/com/fauna/exception/AbortException.java
@@ -1,16 +1,36 @@
 package com.fauna.exception;
 
+import com.fauna.codec.CodecProvider;
+import com.fauna.codec.DefaultCodecProvider;
+import com.fauna.codec.UTF8FaunaParser;
 import com.fauna.response.QueryFailure;
+
+import java.io.IOException;
 
 public class AbortException extends ServiceException {
 
+    private final String abortRaw;
+    private Object abort = null;
+    private final CodecProvider provider = DefaultCodecProvider.SINGLETON;
+
     public AbortException(QueryFailure response) {
         super(response);
+        abortRaw = response.getAbortRaw().get();
     }
 
-    public Object getAbort() {
-        if (this.getResponse().getAbort().isPresent()) {
-            return this.getResponse().getAbort().get();
+    public Object getAbort() throws IOException {
+        return getAbort(Object.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getAbort(Class<T> clazz) throws IOException {
+        if (abort != null) return (T) abort;
+
+        if (this.getResponse().getAbortRaw().isPresent()) {
+            var codec = provider.get(clazz);
+            var parser = new UTF8FaunaParser(abortRaw);
+            abort = codec.decode(parser);
+            return (T) abort;
         } else {
             throw new RuntimeException("Abort Exception missing abort data.");
         }

--- a/src/main/java/com/fauna/exception/AbortException.java
+++ b/src/main/java/com/fauna/exception/AbortException.java
@@ -32,7 +32,7 @@ public class AbortException extends ServiceException {
             abort = codec.decode(parser);
             return (T) abort;
         } else {
-            throw new RuntimeException("Abort Exception missing abort data.");
+            return null;
         }
     }
 }

--- a/src/main/java/com/fauna/response/QueryFailure.java
+++ b/src/main/java/com/fauna/response/QueryFailure.java
@@ -46,7 +46,7 @@ public final class QueryFailure extends QueryResponse {
             message = info.getMessage() != null ? info.getMessage() : "";
             constraintFailures = info.getConstraintFailures();
             // When we stop dealing with default object mappers we can do this more elegantly.
-            abortRaw = info.getAbort().isPresent() ? mapper.writeValueAsString(info.getAbort().get()) : null;
+            abortRaw = info.getAbort().isPresent() ? mapper.writeValueAsString(info.getAbort().get()) : "null";
         }
 
         var maybeSummary = !this.getSummary().isEmpty() ? "\n---\n" + this.getSummary() : "";

--- a/src/test/java/com/fauna/e2e/E2EQueryTest.java
+++ b/src/test/java/com/fauna/e2e/E2EQueryTest.java
@@ -3,23 +3,26 @@ package com.fauna.e2e;
 import com.fauna.client.Fauna;
 import com.fauna.client.FaunaClient;
 import com.fauna.e2e.beans.Author;
+import com.fauna.exception.AbortException;
 import com.fauna.query.QueryOptions;
 import com.fauna.query.builder.Query;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import static com.fauna.query.builder.Query.fql;
-import static org.junit.jupiter.api.Assertions.*;
 import static com.fauna.codec.Parameterized.listOf;
 import static com.fauna.codec.Parameterized.mapOf;
 import static com.fauna.codec.Parameterized.pageOf;
 import static com.fauna.codec.Parameterized.optionalOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class E2EQueryTest {
     public static final FaunaClient c = Fauna.local();
@@ -172,5 +175,19 @@ public class E2EQueryTest {
 
         assertTrue(actual.isPresent());
         assertEquals(42, actual.get());
+    }
+
+    @Test
+    public void query_abortDynamic() throws IOException {
+        var q = fql("abort(8)");
+        var e = assertThrows(AbortException.class, () -> c.query(q));
+        assertEquals(8, e.getAbort());
+    }
+
+    @Test
+    public void query_abortClass() throws IOException {
+        var q = fql("abort({firstName:\"alice\"})");
+        var e = assertThrows(AbortException.class, () -> c.query(q));
+        assertEquals("alice", e.getAbort(Author.class).getFirstName());
     }
 }

--- a/src/test/java/com/fauna/e2e/E2EQueryTest.java
+++ b/src/test/java/com/fauna/e2e/E2EQueryTest.java
@@ -21,6 +21,7 @@ import static com.fauna.codec.Parameterized.mapOf;
 import static com.fauna.codec.Parameterized.pageOf;
 import static com.fauna.codec.Parameterized.optionalOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -175,6 +176,13 @@ public class E2EQueryTest {
 
         assertTrue(actual.isPresent());
         assertEquals(42, actual.get());
+    }
+
+    @Test
+    public void query_abortEmpty() throws IOException {
+        var q = fql("abort(null)");
+        var e = assertThrows(AbortException.class, () -> c.query(q));
+        assertNull(e.getAbort());
     }
 
     @Test

--- a/src/test/java/com/fauna/exception/TestAbortException.java
+++ b/src/test/java/com/fauna/exception/TestAbortException.java
@@ -7,22 +7,25 @@ import com.fauna.response.QueryFailure;
 import com.fauna.response.QueryResponse;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestAbortException {
     ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    public void testAbortDataObject() throws JsonProcessingException {
+    public void testAbortDataObject() throws IOException {
         // Given
         ObjectNode root = mapper.createObjectNode();
         ObjectNode error = root.putObject("error");
         error.put("code", "abort");
         ObjectNode abort = error.putObject("abort");
-        abort.put("some", "reason");
+        ObjectNode num = abort.putObject("num");
+        num.put("@int", "42");
 
         QueryFailure failure = new QueryFailure(500, root, QueryResponse.DEFAULT_STATS);
 
@@ -30,13 +33,16 @@ public class TestAbortException {
         AbortException exc = new AbortException(failure);
 
         // Then
-        HashMap<String, String>  expected = new HashMap<>();
-        expected.put("some", "reason");
+        HashMap<String, Integer>  expected = new HashMap<>();
+        expected.put("num", 42);
         assertEquals(expected, exc.getAbort());
+
+        // Assert caching
+        assertSame(exc.getAbort(), exc.getAbort());
     }
 
     @Test
-    public void testAbortDataString() throws JsonProcessingException {
+    public void testAbortDataString() throws IOException {
         // Given
         ObjectNode root = mapper.createObjectNode();
         ObjectNode error = root.putObject("error");

--- a/src/test/java/com/fauna/exception/TestAbortException.java
+++ b/src/test/java/com/fauna/exception/TestAbortException.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -58,7 +59,7 @@ public class TestAbortException {
     }
 
     @Test
-    public void testAbortDataMissing() throws JsonProcessingException {
+    public void testAbortDataMissing() throws IOException {
         // Given
         ObjectNode root = mapper.createObjectNode();
         ObjectNode error = root.putObject("error");
@@ -69,6 +70,6 @@ public class TestAbortException {
         AbortException exc = new AbortException(failure);
 
         // Then
-        assertThrows(RuntimeException.class, () -> exc.getAbort());
+        assertNull(exc.getAbort());
     }
 }

--- a/src/test/java/com/fauna/response/QueryResponseTest.java
+++ b/src/test/java/com/fauna/response/QueryResponseTest.java
@@ -78,7 +78,7 @@ class QueryResponseTest {
         assertEquals("ErrorCode", failureResponse.getErrorCode());
         assertEquals("ErrorMessage", failureResponse.getMessage());
         assertTrue(failureResponse.getConstraintFailures().isEmpty());
-        assertEquals(Optional.of("AbortData"), failureResponse.getAbort());
+        assertEquals(Optional.of("AbortData"), failureResponse.getAbortRaw());
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Embed a default codec provider in AbortException
* Decode on get and cache the result

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-5043

Aborts return type tag encoded data, so we need to decode it properly. I chose not to expose the codec or codec provider in abort for simplicity–it avoids the complexity of exposing CodecProvider in the API right now. Eventually I'd like to do that, but the lib isn't quite ready yet.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Updated unit tests to deal with type tagged data
* Added two integ tests that issue abort queries to fauna

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.