### PR TITLE
New response models and custom deserializers

### DIFF
--- a/src/main/java/com/fauna/codec/json/PassThroughDeserializer.java
+++ b/src/main/java/com/fauna/codec/json/PassThroughDeserializer.java
@@ -1,0 +1,16 @@
+package com.fauna.codec.json;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+public class PassThroughDeserializer extends JsonDeserializer<String> {
+    @Override
+    public String deserialize(JsonParser jp, DeserializationContext deserializationContext) throws IOException, JacksonException {
+        // We can improve performance by building this from tokens instead.
+        return jp.readValueAsTree().toString();
+    }
+}

--- a/src/main/java/com/fauna/codec/json/QueryTagsDeserializer.java
+++ b/src/main/java/com/fauna/codec/json/QueryTagsDeserializer.java
@@ -1,0 +1,38 @@
+package com.fauna.codec.json;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+public class QueryTagsDeserializer extends JsonDeserializer<Map<String, String>> {
+    @Override
+    public Map<String,String> deserialize(JsonParser jp, DeserializationContext deserializationContext) throws IOException, JacksonException {
+        // We can improve performance by building this from tokens instead.
+        switch (jp.currentToken()) {
+            case VALUE_NULL:
+                return null;
+            case VALUE_STRING:
+                var raw = jp.getValueAsString();
+                Map<String, String> ret = new HashMap<>();
+                if (raw.isEmpty()) {
+                    return ret;
+                }
+
+                String[] tagPairs = jp.getValueAsString().split(",");
+                for (String tagPair : tagPairs) {
+                    String[] tokens = tagPair.split("=");
+                    ret.put(tokens[0], tokens[1]);
+                }
+                return ret;
+            default:
+                throw new JsonParseException(jp, MessageFormat.format("Unexpected token `{0}` deserializing query tags", jp.currentToken()));
+        }
+    }
+}

--- a/src/main/java/com/fauna/response/wire/ConstraintFailureWire.java
+++ b/src/main/java/com/fauna/response/wire/ConstraintFailureWire.java
@@ -1,0 +1,32 @@
+package com.fauna.response.wire;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fauna.codec.json.PassThroughDeserializer;
+
+import java.util.Optional;
+
+public class ConstraintFailureWire {
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("paths")
+    @JsonDeserialize(using = PassThroughDeserializer.class)
+    private String paths;
+
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getPaths() {
+        return paths;
+    }
+}

--- a/src/main/java/com/fauna/response/wire/ErrorInfoWire.java
+++ b/src/main/java/com/fauna/response/wire/ErrorInfoWire.java
@@ -1,0 +1,41 @@
+package com.fauna.response.wire;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fauna.codec.json.PassThroughDeserializer;
+import com.fauna.response.ConstraintFailure;
+
+import java.util.Optional;
+
+public class ErrorInfoWire {
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("constraint_failures")
+    private ConstraintFailureWire[] constraintFailures;
+
+    @JsonProperty("abort")
+    @JsonDeserialize(using = PassThroughDeserializer.class)
+    private String abort;
+
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Optional<ConstraintFailureWire[]> getConstraintFailures() {
+        return Optional.ofNullable(constraintFailures);
+    }
+
+    public Optional<String> getAbort() {
+        return Optional.ofNullable(this.abort);
+    }
+}

--- a/src/main/java/com/fauna/response/wire/QueryResponseWire.java
+++ b/src/main/java/com/fauna/response/wire/QueryResponseWire.java
@@ -1,0 +1,72 @@
+package com.fauna.response.wire;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fauna.codec.json.PassThroughDeserializer;
+import com.fauna.codec.json.QueryTagsDeserializer;
+import com.fauna.response.QueryStats;
+import com.fauna.constants.ResponseFields;
+
+import java.util.Map;
+
+public class QueryResponseWire {
+
+    @JsonProperty(ResponseFields.DATA_FIELD_NAME)
+    @JsonDeserialize(using = PassThroughDeserializer.class)
+    private String data;
+
+    @JsonProperty(ResponseFields.ERROR_FIELD_NAME)
+    private ErrorInfoWire error;
+
+    @JsonProperty(ResponseFields.QUERY_TAGS_FIELD_NAME)
+    @JsonDeserialize(using = QueryTagsDeserializer.class)
+    private Map<String,String> queryTags;
+
+    @JsonProperty(ResponseFields.SCHEMA_VERSION_FIELD_NAME)
+    private Long schemaVersion;
+
+    @JsonProperty(ResponseFields.STATS_FIELD_NAME)
+    private QueryStats stats;
+
+    @JsonProperty(ResponseFields.STATIC_TYPE_FIELD_NAME)
+    private String staticType;
+
+    @JsonProperty(ResponseFields.SUMMARY_FIELD_NAME)
+    private String summary;
+
+    @JsonProperty(ResponseFields.LAST_SEEN_TXN_FIELD_NAME)
+    private Long txnTs;
+
+    public String getData() {
+        return data != null ? data : "null";
+    }
+
+    public ErrorInfoWire getError() {
+        return error;
+    }
+
+    public Map<String, String> getQueryTags() {
+        return queryTags;
+    }
+
+    public Long getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public QueryStats getStats() {
+        return stats;
+    }
+
+    public String getStaticType() {
+        return staticType;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public Long getTxnTs() {
+        return txnTs;
+    }
+}
+

--- a/src/test/java/com/fauna/codec/json/PassThroughDeserializerTest.java
+++ b/src/test/java/com/fauna/codec/json/PassThroughDeserializerTest.java
@@ -1,0 +1,34 @@
+package com.fauna.codec.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fauna.response.wire.QueryResponseWire;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PassThroughDeserializerTest {
+
+    @Test
+    public void deserializeObjectAsRawString() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+        var json = "{\"error\":{\"code\":\"err\",\"abort\":{\"@int\":42}}}";
+        var res = mapper.readValue(json, QueryResponseWire.class);
+        Assertions.assertEquals("{\"@int\":42}", res.getError().getAbort().get());
+    }
+
+    @Test
+    public void deserializeStringAsRawString() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+        var json = "{\"error\":{\"code\":\"err\",\"abort\":\"stringy\"}}";
+        var res = mapper.readValue(json, QueryResponseWire.class);
+        Assertions.assertEquals("\"stringy\"", res.getError().getAbort().get());
+    }
+
+    @Test
+    public void deserializeNull() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+        var json = "{\"error\":{\"code\":\"err\",\"abort\":null}}";
+        var res = mapper.readValue(json, QueryResponseWire.class);
+        Assertions.assertTrue(res.getError().getAbort().isEmpty());
+    }
+}

--- a/src/test/java/com/fauna/codec/json/QueryTagsDeserializerTest.java
+++ b/src/test/java/com/fauna/codec/json/QueryTagsDeserializerTest.java
@@ -1,0 +1,37 @@
+package com.fauna.codec.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fauna.response.wire.QueryResponseWire;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class QueryTagsDeserializerTest {
+
+    @Test
+    public void deserializeNull() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+        var json = "{\"query_tags\":null}";
+        var res = mapper.readValue(json, QueryResponseWire.class);
+        Assertions.assertNull(res.getQueryTags());
+    }
+
+    @Test
+    public void deserializeEmptyString() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+        var json = "{\"query_tags\":\"\"}";
+        var res = mapper.readValue(json, QueryResponseWire.class);
+        Assertions.assertTrue(res.getQueryTags().isEmpty());
+    }
+
+    @Test
+    public void deserializeQueryTags() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+        var json = "{\"query_tags\":\"foo=bar,baz=foo\"}";
+        var res = mapper.readValue(json, QueryResponseWire.class);
+        Assertions.assertNotNull(res.getQueryTags());
+        Assertions.assertEquals(Map.of("foo", "bar", "baz", "foo"), res.getQueryTags());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Add new models for to handle initial response deserialization
* Add QueryTags deserializer
* Add PassThrough deserializer (the JSON tree below the current node is returned as a raw json string)

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-5043

* We want to simplify deserialization of the response
* We need to pass portions of the response through our own codecs

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added unit tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.