### PR TITLE
Handle arrays and other types in page codec

### DIFF
--- a/src/test/java/com/fauna/codec/codecs/PageCodecTest.java
+++ b/src/test/java/com/fauna/codec/codecs/PageCodecTest.java
@@ -14,23 +14,32 @@ import java.util.stream.Stream;
 
 
 public class PageCodecTest extends TestBase {
-    public static final Codec<Page<ClassWithAttributes>> PAGE_CODEC = (Codec<Page<ClassWithAttributes>>) (Codec) DefaultCodecProvider.SINGLETON.get(Page.class, ClassWithAttributes.class);
     public static final String PAGE_WIRE = "{\"@set\":{\"data\":[{\"@doc\":{\"id\":\"123\",\"coll\":{\"@mod\":\"Foo\"},\"ts\":{\"@time\":\"2023-12-15T01:01:01.0010010Z\"},\"first_name\":\"foo\",\"last_name\":\"bar\",\"age\":{\"@int\":\"42\"}}}],\"after\": null}}";
     public static final String DOCUMENT_WIRE = "{\"@doc\":{\"id\":\"123\",\"coll\":{\"@mod\":\"Foo\"},\"ts\":{\"@time\":\"2023-12-15T01:01:01.0010010Z\"},\"first_name\":\"foo\",\"last_name\":\"bar\",\"age\":{\"@int\":\"42\"}}}";
+    public static final String ARRAY_WIRE = "[{\"@int\":\"1\"},{\"@int\":\"2\"}]";
+
     public static final ClassWithAttributes PERSON_WITH_ATTRIBUTES = new ClassWithAttributes("foo","bar",42);
     public static final Page<ClassWithAttributes> PAGE = new Page<>(List.of(PERSON_WITH_ATTRIBUTES),null);
 
+    public static <T> Codec<Page<T>> pageCodecOf(Class<T> clazz) {
+        //noinspection unchecked,rawtypes
+        return (Codec<Page<T>>) (Codec) DefaultCodecProvider.SINGLETON.get(Page.class, clazz);
+    }
+
     public static Stream<Arguments> testCases() {
         return Stream.of(
-                Arguments.of(TestType.RoundTrip, PAGE_CODEC, "null", null, null),
-                Arguments.of(TestType.Decode, PAGE_CODEC, PAGE_WIRE, PAGE, null),
-                Arguments.of(TestType.Decode, PAGE_CODEC, DOCUMENT_WIRE, PAGE, null)
+                Arguments.of(TestType.RoundTrip, ClassWithAttributes.class, "null", null, null),
+                Arguments.of(TestType.Decode, ClassWithAttributes.class, PAGE_WIRE, PAGE, null),
+                Arguments.of(TestType.Decode, ClassWithAttributes.class, DOCUMENT_WIRE, PAGE, null),
+                Arguments.of(TestType.Decode, Integer.class, ARRAY_WIRE, new Page<>(List.of(1, 2), null), null),
+                Arguments.of(TestType.Decode, Integer.class, "{\"@int\":\"1\"}", new Page<>(List.of(1), null), null)
         );
     }
 
     @ParameterizedTest(name = "PageCodec({index}) -> {0}:{1}:{2}:{3}:{4}")
     @MethodSource("testCases")
-    public <T,E extends Exception> void page_runTestCases(TestType testType, Codec<T> codec, String wire, Object obj, E exception) throws IOException {
+    public <T,E extends Exception> void page_runTestCases(TestType testType, Class<T> pageElemClass, String wire, Object obj, E exception) throws IOException {
+        var codec = pageCodecOf(pageElemClass);
         runCase(testType, codec, wire, obj, exception);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Add support for decoding arrays into pages
* Add support for decoding any potential singular type into a single-element page

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-5070

The goal here is to reduce a possible sharp edge where a user decides to call client.paginate() with a query that doesn't return a Fauna Set type. Instead of failing, we'll decode arrays directly into pages as well as wrap whatever type they requested into a page if a single value is returned.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added unit tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.