### PR TITLE
QueryVal, Query Composition, and circular ref bug fixes

### DIFF
--- a/src/main/java/com/fauna/codec/DefaultCodecProvider.java
+++ b/src/main/java/com/fauna/codec/DefaultCodecProvider.java
@@ -12,10 +12,12 @@ import com.fauna.codec.codecs.QueryArrCodec;
 import com.fauna.codec.codecs.QueryCodec;
 import com.fauna.codec.codecs.QueryLiteralCodec;
 import com.fauna.codec.codecs.QueryObjCodec;
+import com.fauna.codec.codecs.QueryValCodec;
 import com.fauna.query.builder.Query;
 import com.fauna.query.builder.QueryArr;
 import com.fauna.query.builder.QueryLiteral;
 import com.fauna.query.builder.QueryObj;
+import com.fauna.query.builder.QueryVal;
 import com.fauna.types.BaseDocument;
 import com.fauna.types.Document;
 import com.fauna.types.NamedDocument;
@@ -38,6 +40,7 @@ public class DefaultCodecProvider implements CodecProvider {
         registry.put(CodecRegistryKey.from(Query.class), new QueryCodec(this));
         registry.put(CodecRegistryKey.from(QueryObj.class), new QueryObjCodec(this));
         registry.put(CodecRegistryKey.from(QueryArr.class), new QueryArrCodec(this));
+        registry.put(CodecRegistryKey.from(QueryVal.class), new QueryValCodec(this));
         registry.put(CodecRegistryKey.from(QueryLiteral.class), new QueryLiteralCodec());
 
         var bdc = new BaseDocumentCodec(this);

--- a/src/main/java/com/fauna/codec/codecs/ClassCodec.java
+++ b/src/main/java/com/fauna/codec/codecs/ClassCodec.java
@@ -47,8 +47,8 @@ public class ClassCodec<T> extends BaseCodec<T> {
             }
 
             var ta = attr.typeArgument() != void.class ? attr.typeArgument() : null;
-            var codec = provider.get(field.getType(), ta);
-            FieldInfo info = new FieldInfo(field, attr.name(), codec);
+            // Don't init the codec here because of potential circular references; instead use a provider.
+            FieldInfo info = new FieldInfo(field, attr.name(), ta, provider);
             fieldsList.add(info);
             byNameMap.put(info.getName(), info);
         }
@@ -86,7 +86,7 @@ public class ClassCodec<T> extends BaseCodec<T> {
                 try {
                     fi.getProperty().setAccessible(true);
                     @SuppressWarnings("unchecked")
-                    T value = (T) fi.getProperty().get(obj);
+                    T value = obj != null ? (T) fi.getProperty().get(obj) : null;
                     @SuppressWarnings("unchecked")
                     Codec<T> codec = fi.getCodec();
                     codec.encode(gen, value);

--- a/src/main/java/com/fauna/query/builder/Query.java
+++ b/src/main/java/com/fauna/query/builder/Query.java
@@ -1,10 +1,7 @@
 package com.fauna.query.builder;
 
-import com.fauna.codec.CodecProvider;
 import com.fauna.query.template.FaunaTemplate;
-import com.fauna.codec.UTF8FaunaGenerator;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterator;
@@ -15,7 +12,7 @@ import java.util.stream.StreamSupport;
  * Represents a Fauna query that is constructed from fragments.
  * This class allows the building of queries from literal and variable parts.
  */
-public class Query{
+public class Query extends QueryFragment<QueryFragment[]> {
 
     private final QueryFragment[] fql;
 
@@ -62,9 +59,10 @@ public class Query{
     /**
      * Retrieves the list of fragments that make up this query.
      *
-     * @return a list of Fragments.
+     * @return an array of Fragments.
      * @throws IllegalArgumentException if a template variable does not have a corresponding entry in the provided args.
      */
+    @Override
     public QueryFragment[] get() {
         return this.fql;
     }

--- a/src/test/java/com/fauna/beans/Circular.java
+++ b/src/test/java/com/fauna/beans/Circular.java
@@ -1,0 +1,9 @@
+package com.fauna.beans;
+
+public class Circular {
+    public static class Inner {
+        public Circular outer;
+    }
+
+    public Inner inner;
+}

--- a/src/test/java/com/fauna/codec/DefaultCodecProviderTest.java
+++ b/src/test/java/com/fauna/codec/DefaultCodecProviderTest.java
@@ -1,5 +1,6 @@
 package com.fauna.codec;
 
+import com.fauna.beans.Circular;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -43,5 +44,13 @@ public class DefaultCodecProviderTest {
         Codec<List<Integer>> codec = (Codec<List<Integer>>) (Codec) cp.get(list.getClass(), Integer.class);
         assertNotNull(codec);
         assertEquals(List.class, codec.getCodecClass());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void get_generateForClassWithCircularRef() {
+        Codec<Circular> codec = cp.get(Circular.class, null);
+        assertNotNull(codec);
+        assertEquals(Circular.class, codec.getCodecClass());
     }
 }

--- a/src/test/java/com/fauna/query/builder/QueryTest.java
+++ b/src/test/java/com/fauna/query/builder/QueryTest.java
@@ -77,7 +77,7 @@ class QueryTest {
     }
 
     @Test
-    public void testQueryBuilderSubQueries() {
+    public void testQueryBuilderSubQueries() throws IOException {
         Map<String, Object> user = Map.of(
                 "name", "Dino",
                 "age", 0,
@@ -85,7 +85,7 @@ class QueryTest {
 
         Query inner = fql("let x = ${my_var}", Map.of("my_var", user));
         Query actual = fql("${inner}\nx { name }", Map.of("inner", inner));
-        QueryFragment[] expected = new QueryFragment[]{new QueryVal(inner), new QueryLiteral("\nx { name }")};
+        QueryFragment[] expected = new QueryFragment[]{inner, new QueryLiteral("\nx { name }")};
         assertArrayEquals(expected, actual.get());
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Make query extend QueryFragment so that it doesn't get wrapped in QueryVal during query building
* Register QueryValCodec
* Lazily get a codec from FieldInfo to allow for classes with circular references.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-5077
BT-5081
BT-5082

Some things weren't working

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added/updated unit tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.