### PR TITLE
Classes with null fields

### DIFF
--- a/src/main/java/com/fauna/codec/codecs/ClassCodec.java
+++ b/src/main/java/com/fauna/codec/codecs/ClassCodec.java
@@ -82,11 +82,17 @@ public class ClassCodec<T> extends BaseCodec<T> {
         }
         for (FieldInfo fi : fields) {
             if (!fi.getName().startsWith("this$")) {
-                gen.writeFieldName(fi.getName());
+                var fieldName = fi.getName();
                 try {
                     fi.getProperty().setAccessible(true);
                     @SuppressWarnings("unchecked")
                     T value = obj != null ? (T) fi.getProperty().get(obj) : null;
+
+                    if (value == null) {
+                        continue;
+                    }
+
+                    gen.writeFieldName(fieldName);
                     @SuppressWarnings("unchecked")
                     Codec<T> codec = fi.getCodec();
                     codec.encode(gen, value);

--- a/src/test/java/com/fauna/beans/ClassWithOptionalFields.java
+++ b/src/test/java/com/fauna/beans/ClassWithOptionalFields.java
@@ -1,0 +1,50 @@
+package com.fauna.beans;
+
+import com.fauna.annotation.FaunaField;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class ClassWithOptionalFields {
+
+    private String firstName;
+
+    private Optional<String> lastName;
+
+    public ClassWithOptionalFields(String firstName, Optional<String> lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public ClassWithOptionalFields() {
+
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public Optional<String> getLastName() {
+        return lastName;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null) return false;
+
+        if (getClass() != o.getClass()) return false;
+
+        ClassWithOptionalFields c = (ClassWithOptionalFields) o;
+
+        return Objects.equals(firstName, c.firstName)
+                && Objects.equals(lastName, c.lastName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName);
+    }
+}

--- a/src/test/java/com/fauna/codec/codecs/ClassCodecTest.java
+++ b/src/test/java/com/fauna/codec/codecs/ClassCodecTest.java
@@ -1,6 +1,7 @@
 package com.fauna.codec.codecs;
 
 import com.fauna.beans.ClassWithFaunaIgnore;
+import com.fauna.beans.ClassWithOptionalFields;
 import com.fauna.beans.ClassWithParameterizedFields;
 import com.fauna.beans.ClassWithRefTagCollision;
 import com.fauna.beans.ClassWithAttributes;
@@ -15,6 +16,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.fauna.codec.codecs.Fixtures.ESCAPED_OBJECT_WIRE_WITH;
@@ -47,6 +49,15 @@ public class ClassCodecTest extends TestBase {
     public static String CLASS_WITH_FAUNA_IGNORE_WIRE = "{\"first_name\":\"foo\",\"last_name\":\"bar\"}";
     public static final ClassWithFaunaIgnore CLASS_WITH_FAUNA_IGNORE = new ClassWithFaunaIgnore("foo", "bar", null);
 
+    // Class with Optional fields
+    private static final Object CLASS_WITH_OPTIONAL_FIELDS_CODEC = DefaultCodecProvider.SINGLETON.get(ClassWithOptionalFields.class);
+    private static final String CLASS_WITH_OPTIONAL_FIELDS_NON_NULL_WIRE =  "{\"firstName\":\"foo\",\"lastName\":\"bar\"}";
+    private static final ClassWithOptionalFields CLASS_WITH_OPTIONAL_NON_NULL_FIELDS = new ClassWithOptionalFields("foo", Optional.of("bar"));
+    private static final String CLASS_WITH_OPTIONAL_FIELDS_EMPTY_WIRE =  "{\"firstName\":\"foo\",\"lastName\":null}";
+    private static final ClassWithOptionalFields CLASS_WITH_OPTIONAL_EMPTY_FIELDS = new ClassWithOptionalFields("foo", Optional.empty());
+    private static final String CLASS_WITH_OPTIONAL_FIELDS_NULL_WIRE =  "{\"firstName\":\"foo\"}";
+    private static final ClassWithOptionalFields CLASS_WITH_OPTIONAL_NULL_FIELDS = new ClassWithOptionalFields("foo", null);
+
     public static Stream<Arguments> testCases() {
         return Stream.of(
                 Arguments.of(TestType.RoundTrip, CLASS_WITH_PARAMETERIZED_FIELDS_CODEC, CLASS_WITH_PARAMETERIZED_FIELDS_WIRE, CLASS_WITH_PARAMETERIZED_FIELDS, null),
@@ -55,7 +66,10 @@ public class ClassCodecTest extends TestBase {
                 Arguments.of(TestType.Encode, CLASS_WITH_FAUNA_IGNORE_CODEC, CLASS_WITH_FAUNA_IGNORE_WIRE, CLASS_WITH_FAUNA_IGNORE_WITH_AGE, null),
                 Arguments.of(TestType.Decode, CLASS_WITH_FAUNA_IGNORE_CODEC, CLASS_WITH_FAUNA_IGNORE_WITH_AGE_WIRE, CLASS_WITH_FAUNA_IGNORE, null),
                 Arguments.of(TestType.Decode, CLASS_WITH_ATTRIBUTES_CODEC, DOCUMENT_WIRE, CLASS_WITH_ATTRIBUTES, null),
-                Arguments.of(TestType.Decode, CLASS_WITH_ATTRIBUTES_CODEC, NULL_DOC_WIRE, null, NULL_DOC_EXCEPTION)
+                Arguments.of(TestType.Decode, CLASS_WITH_ATTRIBUTES_CODEC, NULL_DOC_WIRE, null, NULL_DOC_EXCEPTION),
+                Arguments.of(TestType.RoundTrip, CLASS_WITH_OPTIONAL_FIELDS_CODEC, CLASS_WITH_OPTIONAL_FIELDS_NON_NULL_WIRE, CLASS_WITH_OPTIONAL_NON_NULL_FIELDS, null),
+                Arguments.of(TestType.RoundTrip, CLASS_WITH_OPTIONAL_FIELDS_CODEC, CLASS_WITH_OPTIONAL_FIELDS_NULL_WIRE, CLASS_WITH_OPTIONAL_NULL_FIELDS, null),
+                Arguments.of(TestType.RoundTrip, CLASS_WITH_OPTIONAL_FIELDS_CODEC, CLASS_WITH_OPTIONAL_FIELDS_EMPTY_WIRE, CLASS_WITH_OPTIONAL_EMPTY_FIELDS, null)
         );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
For classes, instead of encoding fields with null values as null by default, skip them. If a user wants to encode a field to null, they must set it to `Optional.empty()`

```
public class MyClass {
    private String firstName;
    private Optional<String> lastName;
    ...
}

new MyClass("foo", Optional.of("bar")) -> {"firstName":"foo","lastName":"bar"}
new MyClass("foo", Optional.empty()) -> {"firstName":"foo","lastName":null}
new MyClass("foo", null) -> {"firstName":"foo"}
```

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-5085

When a user wants to update a document modeled as a user-defined class, we need to be able to handle a three cases:
1. The user wants to set a field to a new non-null value
2. The user wants to set a field to null, erasing the set value in fauna
3. The user wants to leave a field unchanged

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new unit tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.