### PR TITLE
Add support for encoding/decoding enums

### DIFF
--- a/src/main/java/com/fauna/codec/DefaultCodecProvider.java
+++ b/src/main/java/com/fauna/codec/DefaultCodecProvider.java
@@ -3,6 +3,7 @@ package com.fauna.codec;
 import com.fauna.codec.codecs.BaseDocumentCodec;
 import com.fauna.codec.codecs.ClassCodec;
 import com.fauna.codec.codecs.DynamicCodec;
+import com.fauna.codec.codecs.EnumCodec;
 import com.fauna.codec.codecs.ListCodec;
 import com.fauna.codec.codecs.MapCodec;
 import com.fauna.codec.codecs.NullableCodec;
@@ -100,6 +101,10 @@ public class DefaultCodecProvider implements CodecProvider {
         if (clazz == Nullable.class) {
             Codec<E> valueCodec = this.get(ta, null);
             return (Codec<T>) new NullableCodec<E,Nullable<E>>(valueCodec);
+        }
+
+        if (clazz.isEnum()) {
+            return new EnumCodec<>(clazz);
         }
 
         return new ClassCodec<>(clazz, this);

--- a/src/main/java/com/fauna/codec/codecs/EnumCodec.java
+++ b/src/main/java/com/fauna/codec/codecs/EnumCodec.java
@@ -1,0 +1,42 @@
+package com.fauna.codec.codecs;
+
+import com.fauna.codec.UTF8FaunaGenerator;
+import com.fauna.codec.UTF8FaunaParser;
+import com.fauna.exception.ClientException;
+
+import java.io.IOException;
+
+public class EnumCodec<T> extends BaseCodec<T> {
+    private final Class<T> enumType;
+
+    public EnumCodec(Class<T> enumType) {
+        this.enumType = enumType;
+    }
+
+    @Override
+    public T decode(UTF8FaunaParser parser) throws IOException {
+        switch (parser.getCurrentTokenType()) {
+            case NULL:
+                return null;
+            case STRING:
+                //noinspection unchecked
+                return (T) Enum.valueOf((Class<Enum>) enumType, parser.getValueAsString());
+            default:
+                throw new ClientException(this.unexpectedTokenExceptionMessage(parser.getCurrentTokenType()));
+        }
+    }
+
+    @Override
+    public void encode(UTF8FaunaGenerator gen, T obj) throws IOException {
+        if (obj == null) {
+            gen.writeNullValue();
+        } else {
+            gen.writeStringValue(((Enum) obj).name());
+        }
+    }
+
+    @Override
+    public Class<?> getCodecClass() {
+        return Enum.class;
+    }
+}

--- a/src/test/java/com/fauna/codec/codecs/EnumCodecTest.java
+++ b/src/test/java/com/fauna/codec/codecs/EnumCodecTest.java
@@ -1,0 +1,41 @@
+package com.fauna.codec.codecs;
+
+import com.fauna.beans.ClassWithAttributes;
+import com.fauna.beans.ClassWithClientGeneratedIdCollTsAnnotations;
+import com.fauna.beans.ClassWithFaunaIgnore;
+import com.fauna.beans.ClassWithIdCollTsAnnotations;
+import com.fauna.beans.ClassWithInheritanceL2;
+import com.fauna.beans.ClassWithParameterizedFields;
+import com.fauna.beans.ClassWithRefTagCollision;
+import com.fauna.codec.Codec;
+import com.fauna.codec.DefaultCodecProvider;
+import com.fauna.exception.NullDocumentException;
+import com.fauna.types.Module;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.fauna.codec.codecs.Fixtures.ESCAPED_OBJECT_WIRE_WITH;
+
+
+public class EnumCodecTest extends TestBase {
+
+    enum TestEnum {
+        Foo
+    }
+
+    @Test
+    public void class_encodeEnum() throws IOException {
+        var codec = DefaultCodecProvider.SINGLETON.get(TestEnum.class);
+        var wire = "\"Foo\"";
+        var obj = TestEnum.Foo;
+        runCase(TestType.RoundTrip, codec, wire, obj, null);
+    }
+}

--- a/src/test/java/com/fauna/codec/codecs/EnumCodecTest.java
+++ b/src/test/java/com/fauna/codec/codecs/EnumCodecTest.java
@@ -1,28 +1,9 @@
 package com.fauna.codec.codecs;
 
-import com.fauna.beans.ClassWithAttributes;
-import com.fauna.beans.ClassWithClientGeneratedIdCollTsAnnotations;
-import com.fauna.beans.ClassWithFaunaIgnore;
-import com.fauna.beans.ClassWithIdCollTsAnnotations;
-import com.fauna.beans.ClassWithInheritanceL2;
-import com.fauna.beans.ClassWithParameterizedFields;
-import com.fauna.beans.ClassWithRefTagCollision;
-import com.fauna.codec.Codec;
 import com.fauna.codec.DefaultCodecProvider;
-import com.fauna.exception.NullDocumentException;
-import com.fauna.types.Module;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
-
-import static com.fauna.codec.codecs.Fixtures.ESCAPED_OBJECT_WIRE_WITH;
 
 
 public class EnumCodecTest extends TestBase {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
Add an enum codec that encodes enums into a string and decodes them from a string. Strings must match the exact case of the enum value.

I opted for strings because strings carry information and aren't coupled to the order in which enum values are defined. I think end users will be happy that we don't store enums as ints in our database from this driver.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-5093

We can't encode or decode enums.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added a unit test

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.