### PR TITLE
Remove unnecessary genericTypeArg annotation field

### DIFF
--- a/src/main/java/com/fauna/annotation/FaunaField.java
+++ b/src/main/java/com/fauna/annotation/FaunaField.java
@@ -13,5 +13,4 @@ import java.lang.annotation.Target;
 public @interface FaunaField {
 
     String name() default "";
-    Class<?> genericTypeArgument() default void.class;
 }

--- a/src/main/java/com/fauna/annotation/FaunaFieldImpl.java
+++ b/src/main/java/com/fauna/annotation/FaunaFieldImpl.java
@@ -14,11 +14,6 @@ public class FaunaFieldImpl implements FaunaField {
     }
 
     @Override
-    public Class<?> genericTypeArgument() {
-        return annotation != null ? annotation.genericTypeArgument() : null;
-    }
-
-    @Override
     public Class<? extends java.lang.annotation.Annotation> annotationType() {
         return FaunaField.class;
     }

--- a/src/main/java/com/fauna/codec/codecs/ClassCodec.java
+++ b/src/main/java/com/fauna/codec/codecs/ClassCodec.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -62,10 +64,17 @@ public class ClassCodec<T> extends BaseCodec<T> {
                         "Duplicate field name " + name + " in " + ty);
             }
 
-            var ta = attr.genericTypeArgument() != void.class ? attr.genericTypeArgument() : null;
+            Type type = field.getGenericType();
+            FieldInfo info;
 
             // Don't init the codec here because of potential circular references; instead use a provider.
-            FieldInfo info = new FieldInfo(field, name, ta, provider, fieldType);
+            if (type instanceof ParameterizedType) {
+                ParameterizedType pType = (ParameterizedType)type;
+                info = new FieldInfo(field, name, (Class<?>) pType.getRawType(), pType.getActualTypeArguments(), provider, fieldType);
+            } else {
+                info = new FieldInfo(field, name, field.getType(), null, provider, fieldType);
+            }
+
             fieldsList.add(info);
             byNameMap.put(info.getName(), info);
         }

--- a/src/main/java/com/fauna/mapping/FieldInfo.java
+++ b/src/main/java/com/fauna/mapping/FieldInfo.java
@@ -4,20 +4,23 @@ import com.fauna.codec.Codec;
 import com.fauna.codec.CodecProvider;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 public final class FieldInfo {
 
     private final String name;
-    private final Field field;
-    private final Class<?> typeArg;
     private final CodecProvider provider;
     private final FieldType fieldType;
+    private final Class<?> clazz;
+    private final Type[] genericTypeArgs;
+    private final Field field;
     private Codec<?> codec;
 
-    public FieldInfo(Field field, String name, Class<?> typeArg, CodecProvider provider, FieldType fieldType) {
-        this.name = name;
+    public FieldInfo(Field field, String name, Class<?> clazz, Type[] genericTypeArgs, CodecProvider provider, FieldType fieldType) {
         this.field = field;
-        this.typeArg = typeArg;
+        this.name = name;
+        this.clazz = clazz;
+        this.genericTypeArgs = genericTypeArgs;
         this.provider = provider;
         this.fieldType = fieldType;
     }
@@ -26,12 +29,8 @@ public final class FieldInfo {
         return name;
     }
 
-    public Field getField() {
-        return field;
-    }
-
     public Class<?> getType() {
-        return field.getType();
+        return clazz;
     }
 
     public FieldType getFieldType() {
@@ -45,9 +44,19 @@ public final class FieldInfo {
             // check again in case it was set by another thread
             if (codec != null) return codec;
 
-            codec = provider.get(field.getType(), typeArg);
+            if (genericTypeArgs == null || genericTypeArgs.length == 0) {
+                codec = provider.get(clazz, null);
+            } else if (genericTypeArgs.length == 1) {
+                codec = provider.get(clazz, (Class<?>) genericTypeArgs[0]);
+            } else {
+                codec = provider.get(clazz, (Class<?>)  genericTypeArgs[1]);
+            }
         }
 
         return codec;
+    }
+
+    public Field getField() {
+        return field;
     }
 }

--- a/src/test/java/com/fauna/beans/ClassWithParameterizedFields.java
+++ b/src/test/java/com/fauna/beans/ClassWithParameterizedFields.java
@@ -5,26 +5,31 @@ import com.fauna.annotation.FaunaField;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public class ClassWithParameterizedFields {
 
     public ClassWithParameterizedFields() {
     }
 
-    public ClassWithParameterizedFields(String firstName, List<String> list, Map<String,Integer> map) {
+    public ClassWithParameterizedFields(String firstName, List<ClassWithAttributes> list, Map<String,Integer> map, Optional<String> optional) {
         this.firstName = firstName;
         this.list = list;
         this.map = map;
+        this.optional = optional;
     }
 
     @FaunaField(name = "first_name")
     public String firstName;
 
-    @FaunaField(name = "a_list", genericTypeArgument = String.class)
-    public List<String> list;
+    @FaunaField(name = "a_list")
+    public List<ClassWithAttributes> list;
 
-    @FaunaField(name = "a_map", genericTypeArgument = Integer.class)
+    @FaunaField(name = "a_map")
     public Map<String,Integer> map;
+
+    @FaunaField(name = "an_optional")
+    public Optional<String> optional;
 
     @Override
     public boolean equals(Object o) {
@@ -38,11 +43,12 @@ public class ClassWithParameterizedFields {
 
         return list.equals(c.list)
                 && map.equals(c.map)
+                && Objects.equals(optional, c.optional)
                 && firstName.equals(c.firstName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(list, map, firstName);
+        return Objects.hash(list, map, firstName, optional);
     }
 }

--- a/src/test/java/com/fauna/codec/codecs/ClassCodecTest.java
+++ b/src/test/java/com/fauna/codec/codecs/ClassCodecTest.java
@@ -23,22 +23,13 @@ import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.fauna.codec.codecs.Fixtures.ESCAPED_OBJECT_WIRE_WITH;
 
 
 public class ClassCodecTest extends TestBase {
-
-    // Class with tag collision
-    public static final Codec<ClassWithRefTagCollision> CLASS_WITH_REF_TAG_COLLISION_CODEC = DefaultCodecProvider.SINGLETON.get(ClassWithRefTagCollision.class);
-    public static final String REF_TAG_COLLISION_WIRE = ESCAPED_OBJECT_WIRE_WITH("@ref");
-    public static final ClassWithRefTagCollision CLASS_WITH_REF_TAG_COLLISION = new ClassWithRefTagCollision("not");
-
-    // Class with parameterized Fields
-    public static final Codec<ClassWithParameterizedFields>  CLASS_WITH_PARAMETERIZED_FIELDS_CODEC = DefaultCodecProvider.SINGLETON.get(ClassWithParameterizedFields.class);
-    public static final String CLASS_WITH_PARAMETERIZED_FIELDS_WIRE = "{\"first_name\":\"foo\",\"a_list\":[\"item1\"],\"a_map\":{\"key1\":{\"@int\":\"42\"}}}";
-    public static final ClassWithParameterizedFields CLASS_WITH_PARAMETERIZED_FIELDS = new ClassWithParameterizedFields("foo",  List.of("item1"), Map.of("key1", 42));
 
     // Class with FaunaField attributes
     public static final Codec<ClassWithAttributes> CLASS_WITH_ATTRIBUTES_CODEC = DefaultCodecProvider.SINGLETON.get(ClassWithAttributes.class);
@@ -47,6 +38,15 @@ public class ClassCodecTest extends TestBase {
     public static final String NULL_DOC_WIRE = "{\"@ref\":{\"id\":\"123\",\"coll\":{\"@mod\":\"Foo\"},\"exists\":false,\"cause\":\"not found\"}}";
     public static final NullDocumentException NULL_DOC_EXCEPTION = new NullDocumentException("123", new Module("Foo"), "not found");
 
+    // Class with tag collision
+    public static final Codec<ClassWithRefTagCollision> CLASS_WITH_REF_TAG_COLLISION_CODEC = DefaultCodecProvider.SINGLETON.get(ClassWithRefTagCollision.class);
+    public static final String REF_TAG_COLLISION_WIRE = ESCAPED_OBJECT_WIRE_WITH("@ref");
+    public static final ClassWithRefTagCollision CLASS_WITH_REF_TAG_COLLISION = new ClassWithRefTagCollision("not");
+
+    // Class with parameterized Fields
+    public static final Codec<ClassWithParameterizedFields>  CLASS_WITH_PARAMETERIZED_FIELDS_CODEC = DefaultCodecProvider.SINGLETON.get(ClassWithParameterizedFields.class);
+    public static final String CLASS_WITH_PARAMETERIZED_FIELDS_WIRE = "{\"first_name\":\"foo\",\"a_list\":[{\"first_name\":\"foo\",\"last_name\":\"bar\",\"age\":{\"@int\":\"42\"}}],\"a_map\":{\"key1\":{\"@int\":\"42\"}},\"an_optional\":\"Fauna\"}";
+    public static final ClassWithParameterizedFields CLASS_WITH_PARAMETERIZED_FIELDS = new ClassWithParameterizedFields("foo",  List.of(CLASS_WITH_ATTRIBUTES), Map.of("key1", 42), Optional.of("Fauna"));
 
     // Class with FaunaIgnore attributes
     public static final Codec<ClassWithFaunaIgnore> CLASS_WITH_FAUNA_IGNORE_CODEC = DefaultCodecProvider.SINGLETON.get(ClassWithFaunaIgnore.class);

--- a/src/test/java/com/fauna/e2e/E2EQueryTest.java
+++ b/src/test/java/com/fauna/e2e/E2EQueryTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -115,7 +116,7 @@ public class E2EQueryTest {
     }
 
     @Test
-    public void query_arrayOfPerson() {
+    public void query_arrayOfPersonIncoming() {
         var q = fql("Author.all().toArray()");
 
         var res = c.query(q, listOf(Author.class));
@@ -125,6 +126,17 @@ public class E2EQueryTest {
         var elem = res.getData().get(0);
         assertEquals("Alice", elem.getFirstName());
     }
+
+    @Test
+    public void query_arrayOfPersonOutgoing() {
+        var q = fql("${var}", Map.of("var", List.of(new Author("alice","smith","w", 42))));
+
+        var res = c.query(q);
+
+        List<Map<String, Object>> elem = (List<Map<String, Object>>) res.getData();
+        assertEquals("alice", elem.get(0).get("firstName"));
+    }
+
 
     @Test
     public void query_mapOfPerson() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Remove genericTypeArgument from FaunaField
* Branch FieldInfo construction on whether Field.getGenericType() is a ParameterizedType or not

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-5098

I realized while fixing some other things that I misunderstood an aspect of type erasure in Java and as a result built an overly complex annotation to deal with it.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated and extended tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.