### PR TITLE
[Implement-error-parsers] Refactor to use JsonParser instead of ObjectMapper for parsing errors.

### DIFF
--- a/src/main/java/com/fauna/constants/ResponseFields.java
+++ b/src/main/java/com/fauna/constants/ResponseFields.java
@@ -28,6 +28,8 @@ public final class ResponseFields {
     public static final String ERROR_MESSAGE_FIELD_NAME = "message";
     public static final String ERROR_CONSTRAINT_FAILURES_FIELD_NAME = "constraint_failures";
     public static final String ERROR_ABORT_FIELD_NAME = "abort";
+    public static final String ERROR_NAME_FIELD_NAME = "name";
+    public static final String ERROR_PATHS_FIELD_NAME = "paths";
 
     // Stream-related fields
     public static final String STREAM_TYPE_FIELD_NAME = "type";

--- a/src/main/java/com/fauna/exception/ServiceException.java
+++ b/src/main/java/com/fauna/exception/ServiceException.java
@@ -1,6 +1,7 @@
 package com.fauna.exception;
 
 import java.util.Map;
+import java.util.Optional;
 
 import com.fauna.response.QueryFailure;
 import com.fauna.response.QueryStats;
@@ -76,12 +77,12 @@ public class ServiceException extends FaunaException {
     }
 
     /**
-     * Returns the faled query's last transaction timestamp.
+     * Returns the failed query's last transaction timestamp.
      *
      * @return the transaction timestamp as a long value
      */
-    public long getTxnTs() {
-        return this.response.getLastSeenTxn();
+    public Optional<Long> getTxnTs() {
+        return Optional.ofNullable(this.response.getLastSeenTxn());
     }
 
     /**

--- a/src/main/java/com/fauna/response/ConstraintFailure.java
+++ b/src/main/java/com/fauna/response/ConstraintFailure.java
@@ -149,7 +149,7 @@ public class ConstraintFailure {
                         }
                         builder.paths(paths.toArray(new PathElement[paths.size()][]));
                     } else if (firstPathToken != JsonToken.VALUE_NULL) {
-                        throw new ClientException("Constraint failure path should be array or null, got: " + firstPathToken.toString());
+                        throw new ClientResponseException("Constraint failure path should be array or null, got: " + firstPathToken.toString());
                     }
                     break;
             }

--- a/src/main/java/com/fauna/response/ConstraintFailure.java
+++ b/src/main/java/com/fauna/response/ConstraintFailure.java
@@ -1,5 +1,13 @@
 package com.fauna.response;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fauna.constants.ResponseFields;
+import com.fauna.exception.ClientException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -8,12 +16,130 @@ public class ConstraintFailure {
 
     private final String name;
 
-    private final List<List<Object>> paths;
+    private final PathElement[][] paths;
 
-    public ConstraintFailure(String message, String name, List<List<Object>> paths) {
+    public ConstraintFailure(String message, String name, List<List<Object>> pathLists) {
+        this.message = message;
+        this.name = name;
+        this.paths = new PathElement[pathLists.size()][];
+        for (int i = 0; i < pathLists.size(); i++) {
+            this.paths[i] = new PathElement[pathLists.get(i).size()];
+            for (int j = 0; j < this.paths[i].length; j++) {
+                Object element = pathLists.get(i).get(j);
+                if (element instanceof String) {
+                    paths[i][j] = new PathElement((String) element);
+                } else if (element instanceof Integer) {
+                    paths[i][j] = new PathElement((Integer) element);
+                }
+            }
+        }
+    }
+
+    public ConstraintFailure(String message, String name, PathElement[][] paths) {
         this.message = message;
         this.name = name;
         this.paths = paths;
+    }
+
+    public static class PathElement {
+        private String sVal = null;
+        private Integer iVal = null;
+
+        public PathElement(String sVal) {
+            this.sVal = sVal;
+        }
+
+        public PathElement(Integer iVal) {
+            this.iVal = iVal;
+        }
+
+        /**
+         * Note that this parser does not advance the parser.
+         * @param parser
+         * @return
+         * @throws IOException
+         */
+        public static PathElement parse(JsonParser parser) throws IOException {
+            if (parser.currentToken().isNumeric()) {
+                return new PathElement(parser.getValueAsInt());
+            } else {
+                return new PathElement(parser.getText());
+            }
+        }
+
+        public String toString() {
+            return sVal == null ? String.valueOf(iVal) : sVal;
+        }
+    }
+
+
+    public static class Builder {
+        String message = null;
+        String name = null;
+        PathElement[][] paths;
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder paths(PathElement[][] paths) {
+            this.paths = paths;
+            return this;
+        }
+
+        public ConstraintFailure build() {
+            return new ConstraintFailure(this.message, this.name, this.paths);
+        }
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ConstraintFailure parse(JsonParser parser) throws IOException {
+        JsonToken firstToken = parser.nextToken();
+        if (firstToken == JsonToken.VALUE_NULL) {
+            return null;
+        } else if (firstToken != JsonToken.START_OBJECT) {
+            throw new ClientException("Constraint failure should be a JSON object or null, got" + firstToken);
+        }
+        Builder builder = ConstraintFailure.builder();
+        while (parser.nextToken() == JsonToken.FIELD_NAME) {
+            String fieldName = parser.getValueAsString();
+            switch (fieldName) {
+                case ResponseFields.ERROR_MESSAGE_FIELD_NAME:
+                    builder.message(parser.nextTextValue());
+                    break;
+                case ResponseFields.ERROR_NAME_FIELD_NAME:
+                    builder.name(parser.nextTextValue());
+                case ResponseFields.ERROR_PATHS_FIELD_NAME:
+                    List<PathElement[]> paths = new ArrayList<>();
+                    JsonToken firstPathToken = parser.nextToken();
+                    if (firstPathToken != JsonToken.START_ARRAY || firstPathToken != JsonToken.VALUE_NULL) {
+                        throw new ClientException("Constraint failure should be array or null, got: " + firstPathToken.toString());
+                    }
+                    while (parser.nextToken() != JsonToken.END_ARRAY) {
+                        List<PathElement> path = new ArrayList<>();
+                        if (parser.nextToken() == JsonToken.START_ARRAY) {
+                            JsonToken pathToken = parser.nextToken();
+                            while (pathToken != JsonToken.END_ARRAY) {
+                                path.add(PathElement.parse(parser));
+                            }
+                        }
+                        paths.add(path.toArray(new PathElement[path.size()]));
+                    }
+                    builder.paths(paths.toArray(new PathElement[paths.size()][]));
+            }
+        }
+        return builder.build();
+
     }
 
     public String getMessage() {
@@ -24,8 +150,8 @@ public class ConstraintFailure {
         return Optional.ofNullable(this.name);
     }
 
-    public List<List<Object>> getPaths() {
-        return paths != null ? paths : List.of();
+    public PathElement[][] getPaths() {
+        return paths;
     }
 
 }

--- a/src/main/java/com/fauna/response/ConstraintFailure.java
+++ b/src/main/java/com/fauna/response/ConstraintFailure.java
@@ -21,6 +21,8 @@ public class ConstraintFailure {
 
     private final PathElement[][] paths;
 
+    // This constructor is called by the QueryFailure constructor, which is getting deprecated.
+    @Deprecated
     public ConstraintFailure(String message, String name, List<List<Object>> pathLists) {
         this.message = message;
         this.name = name;

--- a/src/main/java/com/fauna/response/ConstraintFailure.java
+++ b/src/main/java/com/fauna/response/ConstraintFailure.java
@@ -3,11 +3,9 @@ package com.fauna.response;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fauna.constants.ResponseFields;
-import com.fauna.exception.ClientException;
 import com.fauna.exception.ClientResponseException;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/com/fauna/response/ErrorInfo.java
+++ b/src/main/java/com/fauna/response/ErrorInfo.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fauna.codec.Codec;
 import com.fauna.codec.DefaultCodecProvider;
 import com.fauna.codec.UTF8FaunaParser;
-import com.fauna.exception.ClientException;
 import com.fauna.exception.ClientResponseException;
 
 import java.io.IOException;
@@ -101,7 +100,7 @@ public class ErrorInfo {
 
     public static ErrorInfo parse(JsonParser parser) throws IOException {
         if (parser.nextToken() != JsonToken.START_OBJECT) {
-            throw new ClientException("Error parsing error info, got token" + parser.currentToken());
+            throw new ClientResponseException("Error parsing error info, got token" + parser.currentToken());
         }
         Builder builder = ErrorInfo.builder();
 
@@ -132,7 +131,7 @@ public class ErrorInfo {
                         builder.constraintFailures(failures);
                         break;
                     } else {
-                        throw new ClientException("Unexpected for constraint failures: " + token);
+                        throw new ClientResponseException("Unexpected token in constraint failures: " + token);
                     }
                 default: throw new ClientResponseException("Unexpected token in error info: " + parser.currentToken());
             }

--- a/src/main/java/com/fauna/response/ErrorInfo.java
+++ b/src/main/java/com/fauna/response/ErrorInfo.java
@@ -1,5 +1,19 @@
 package com.fauna.response;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fauna.exception.ClientException;
+import com.fauna.exception.ClientResponseException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.fauna.constants.ResponseFields.ERROR_CODE_FIELD_NAME;
+import static com.fauna.constants.ResponseFields.ERROR_CONSTRAINT_FAILURES_FIELD_NAME;
+import static com.fauna.constants.ResponseFields.ERROR_MESSAGE_FIELD_NAME;
+
 /**
  * This class will encapsulate all the information Fauna returns about errors including constraint failures, and
  * abort data, for now it just has the code and message.
@@ -7,10 +21,14 @@ package com.fauna.response;
 public class ErrorInfo {
     private final String code;
     private final String message;
+    private final ConstraintFailure[] constraintFailures;
+    private final String abort;
 
-    public ErrorInfo(String code, String message) {
+    public ErrorInfo(String code, String message, ConstraintFailure[] constraintFailures, String abort) {
         this.code = code;
         this.message = message;
+        this.constraintFailures = constraintFailures;
+        this.abort = abort;
     }
 
     public String getCode() {
@@ -19,5 +37,84 @@ public class ErrorInfo {
 
     public String getMessage() {
         return message;
+    }
+
+    public Optional<ConstraintFailure[]> getConstraintFailures() {
+        return Optional.ofNullable(this.constraintFailures);
+    }
+    public String getAbort() {
+        return this.abort;
+    }
+
+    public static class Builder {
+        String code = null;
+        String message = null;
+        ConstraintFailure[] constraintFailures = null;
+        String abort = null;
+
+        public Builder code(String code) {
+            this.code = code;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder abort(Object abort) {
+            this.abort = abort.toString();
+            return this;
+        }
+
+        public Builder constraintFailures(List<ConstraintFailure> constraintFailures) {
+            this.constraintFailures = constraintFailures.toArray(new ConstraintFailure[constraintFailures.size()]);
+            return this;
+        }
+
+        public ErrorInfo build() {
+            return new ErrorInfo(this.code, this.message, this.constraintFailures, "abort parsing not implemented");
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ErrorInfo parse(JsonParser parser) throws IOException {
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+            throw new ClientException("Error parsing error info, got token" + parser.currentToken());
+        }
+        Builder builder = ErrorInfo.builder();
+
+        while (parser.nextToken() == JsonToken.FIELD_NAME) {
+            String fieldName = parser.getCurrentName();
+            switch (fieldName) {
+                case ERROR_CODE_FIELD_NAME:
+                    builder.code(parser.nextTextValue());
+                    break;
+                case ERROR_MESSAGE_FIELD_NAME:
+                    builder.message(parser.nextTextValue());
+                    break;
+                case ERROR_CONSTRAINT_FAILURES_FIELD_NAME:
+                    List<ConstraintFailure> failures = new ArrayList<>();
+                    JsonToken token = parser.nextToken();
+                    if (token == JsonToken.VALUE_NULL) {
+                        break;
+                    } else if (token == JsonToken.START_ARRAY) {
+                        JsonToken nextToken = parser.nextToken();
+                        while (nextToken == JsonToken.START_OBJECT) {
+                            failures.add(ConstraintFailure.parse(parser));
+                            nextToken = parser.nextToken();
+                        }
+                        builder.constraintFailures(failures);
+                        break;
+                    } else {
+                        throw new ClientException("Unexpected for constraint failures: " + token);
+                    }
+                default: throw new ClientResponseException("Unexpected token in error info: " + parser.currentToken());
+            }
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/com/fauna/response/QueryFailure.java
+++ b/src/main/java/com/fauna/response/QueryFailure.java
@@ -38,9 +38,12 @@ public final class QueryFailure extends QueryResponse {
      * Initializes a new instance of the {@link QueryFailure} class, parsing the provided raw
      * response to extract error information.
      *
+     * @deprecated This method will be removed when QueryResponseWire is removed.
+     *
      * @param statusCode The HTTP status code.
      * @param response   The parsed response.
      */
+    @Deprecated
     public QueryFailure(int statusCode, QueryResponseWire response) {
         super(response.getTxnTs(), response.getSummary(), response.getSchemaVersion(), response.getQueryTags(), response.getStats());
         ErrorInfoWire errorInfoWire = response.getError();

--- a/src/main/java/com/fauna/response/QueryFailure.java
+++ b/src/main/java/com/fauna/response/QueryFailure.java
@@ -49,14 +49,14 @@ public final class QueryFailure extends QueryResponse {
         ErrorInfoWire errorInfoWire = response.getError();
         ObjectMapper mapper = new ObjectMapper();
         AtomicReference<TreeNode> abortTree = new AtomicReference<>(mapper.createObjectNode());
-        errorInfoWire.getAbort().ifPresent(abort -> {
-            try {
-                abortTree.set(new ObjectMapper().readTree(abort));
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
-        });
         if (errorInfoWire != null) {
+            errorInfoWire.getAbort().ifPresent(abort -> {
+                try {
+                    abortTree.set(new ObjectMapper().readTree(abort));
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            });
             this.errorInfo = new ErrorInfo(errorCode, errorInfoWire.getMessage(), errorInfoWire.getConstraintFailureArray().orElse(null), abortTree.get());
         } else {
             this.errorInfo = new ErrorInfo(errorCode, null, null, null);

--- a/src/main/java/com/fauna/response/QueryFailure.java
+++ b/src/main/java/com/fauna/response/QueryFailure.java
@@ -6,23 +6,32 @@ import com.fauna.exception.ClientException;
 import com.fauna.exception.ClientResponseException;
 import com.fauna.exception.CodecException;
 import com.fauna.response.wire.ConstraintFailureWire;
+import com.fauna.response.wire.ErrorInfoWire;
 import com.fauna.response.wire.QueryResponseWire;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public final class QueryFailure extends QueryResponse {
 
     private final int statusCode;
+    private final ErrorInfo errorInfo;
     private String errorCode = "";
     private String message = "";
 
     private List<ConstraintFailure> constraintFailures;
     private String abortString;
 
-    private final String fullMessage;
+
+    public QueryFailure(int statusCode, ErrorInfo errorInfo, Long schemaVersion, Map<String, String> queryTags, QueryStats stats) {
+        super(null, null, schemaVersion, queryTags, stats);
+        this.statusCode = statusCode;
+        this.errorInfo = errorInfo;
+    }
 
     /**
      * Initializes a new instance of the {@link QueryFailure} class, parsing the provided raw
@@ -32,7 +41,13 @@ public final class QueryFailure extends QueryResponse {
      * @param response   The parsed response.
      */
     public QueryFailure(int statusCode, QueryResponseWire response) {
-        super(response);
+        super(response.getTxnTs(), response.getSummary(), response.getSchemaVersion(), response.getQueryTags(), response.getStats());
+        ErrorInfoWire errorInfoWire = response.getError();
+        if (errorInfoWire != null) {
+            this.errorInfo = new ErrorInfo(errorCode, errorInfoWire.getMessage(), errorInfoWire.getConstraintFailureArray().orElse(null), errorInfoWire.getAbort().orElse(null));
+        } else {
+            this.errorInfo = new ErrorInfo(errorCode, null, null, null);
+        }
 
         this.statusCode = statusCode;
 
@@ -61,14 +76,6 @@ public final class QueryFailure extends QueryResponse {
             }
         }
 
-        var maybeSummary = this.getSummary() != null ? "\n---\n" + this.getSummary() : "";
-        fullMessage = String.format(
-                "%d (%s): %s%s",
-                this.getStatusCode(),
-                this.getErrorCode(),
-                this.getMessage(),
-                maybeSummary);
-
     }
 
     public int getStatusCode() {
@@ -84,7 +91,10 @@ public final class QueryFailure extends QueryResponse {
     }
 
     public String getFullMessage() {
-        return fullMessage;
+        String summarySuffix = this.getSummary() != null ? "\n---\n" + this.getSummary() : "";
+        return String.format("%d (%s): %s%s",
+                this.getStatusCode(), this.getErrorCode(), this.getMessage(), summarySuffix);
+
     }
 
     public Optional<List<ConstraintFailure>> getConstraintFailures() {

--- a/src/main/java/com/fauna/response/QueryResponse.java
+++ b/src/main/java/com/fauna/response/QueryResponse.java
@@ -6,10 +6,8 @@ import com.fauna.codec.Codec;
 import com.fauna.exception.ClientResponseException;
 import com.fauna.exception.ErrorHandler;
 import com.fauna.exception.FaunaException;
-import com.fauna.exception.ProtocolException;
 import com.fauna.response.wire.QueryResponseWire;
 
-import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.util.Map;
 
@@ -30,6 +28,15 @@ public abstract class QueryResponse {
         summary = response.getSummary();
         stats = response.getStats();
         queryTags = response.getQueryTags();
+    }
+
+    QueryResponse(Long lastSeenTxn, String summary, Long schemaVersion,
+                  Map<String, String> queryTags, QueryStats stats) {
+        this.lastSeenTxn = lastSeenTxn;
+        this.summary = summary;
+        this.schemaVersion = schemaVersion;
+        this.stats = stats;
+        this.queryTags = queryTags;
     }
 
     /**

--- a/src/main/java/com/fauna/response/QueryResponseHandler.java
+++ b/src/main/java/com/fauna/response/QueryResponseHandler.java
@@ -1,0 +1,35 @@
+package com.fauna.response;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fauna.codec.Codec;
+import com.fauna.exception.ClientResponseException;
+import com.fauna.exception.ErrorHandler;
+import com.fauna.response.wire.QueryResponseWire;
+
+import java.net.http.HttpResponse;
+
+public class QueryResponseHandler {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static <T> QueryResponse handle(HttpResponse<String> response, Codec<T> codec) {
+        String body = response.body();
+        try {
+            if (response.statusCode() >= 400) {
+                ErrorHandler.handleErrorResponse(response.statusCode(), null, body);
+            }
+            var responseInternal = mapper.readValue(body, QueryResponseWire.class);
+            return new QuerySuccess<>(codec, responseInternal);
+        } catch (JsonProcessingException exc) { // Jackson JsonProcessingException subclasses IOException
+            throw new ClientResponseException("Failed to handle error response.", exc, response.statusCode());
+        }
+
+    }
+
+    /*
+    private static <T> QuerySuccess<T> parse(JsonParser parser) {
+
+    } */
+
+}

--- a/src/main/java/com/fauna/response/wire/ConstraintFailureWire.java
+++ b/src/main/java/com/fauna/response/wire/ConstraintFailureWire.java
@@ -3,9 +3,9 @@ package com.fauna.response.wire;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fauna.codec.json.PassThroughDeserializer;
+import com.fauna.response.ConstraintFailure;
 
-import java.util.Optional;
-
+@Deprecated
 public class ConstraintFailureWire {
     @JsonProperty("message")
     private String message;
@@ -28,5 +28,13 @@ public class ConstraintFailureWire {
 
     public String getPaths() {
         return paths;
+    }
+
+    public ConstraintFailure toConstraintFailure() {
+        ConstraintFailure.PathElement[][] paths = new ConstraintFailure.PathElement[1][1];
+        // This is incorrect but it will be removed soon.
+        paths[0][0] = new ConstraintFailure.PathElement(this.getPaths());
+        return new ConstraintFailure(this.name, this.message, paths);
+
     }
 }

--- a/src/main/java/com/fauna/response/wire/ErrorInfoWire.java
+++ b/src/main/java/com/fauna/response/wire/ErrorInfoWire.java
@@ -1,9 +1,20 @@
 package com.fauna.response.wire;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fauna.codec.json.PassThroughDeserializer;
+import com.fauna.exception.ClientException;
+import com.fauna.response.ConstraintFailure;
 
+import static com.fauna.constants.ResponseFields.ERROR_CODE_FIELD_NAME;
+import static com.fauna.constants.ResponseFields.ERROR_CONSTRAINT_FAILURES_FIELD_NAME;
+import static com.fauna.constants.ResponseFields.ERROR_MESSAGE_FIELD_NAME;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -25,6 +36,77 @@ public class ErrorInfoWire {
     @JsonDeserialize(using = PassThroughDeserializer.class)
     private String abort;
 
+    public ErrorInfoWire() {}  // Required for ObjectMapper
+
+    public ErrorInfoWire(String code, String message, ConstraintFailureWire[] constraintFailures, String abort) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public static class Builder {
+        String code = null;
+        String message = "";
+        ConstraintFailureWire[] constraintFailures = null;
+        String abort = null;
+
+        public Builder code(String code) {
+            this.code = code;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder abort(Object abort) {
+            this.abort = abort.toString();
+            return this;
+        }
+
+        public ErrorInfoWire build() {
+            return new ErrorInfoWire(this.code, this.message, this.constraintFailures, "abort parsing not implemented");
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ErrorInfoWire parse(JsonParser parser) throws IOException {
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+            throw new ClientException("Error parsing error info, got token" + parser.currentToken());
+        }
+        Builder builder = ErrorInfoWire.builder();
+
+        while (parser.nextToken() != JsonToken.FIELD_NAME) {
+            String fieldName = parser.getCurrentName();
+            switch (fieldName) {
+                case ERROR_CODE_FIELD_NAME:
+                    parser.nextToken();
+                    builder.code(parser.getText());
+                    break;
+                case ERROR_MESSAGE_FIELD_NAME:
+                    parser.nextToken();
+                    builder.message(parser.getText());
+                    break;
+                case ERROR_CONSTRAINT_FAILURES_FIELD_NAME:
+                    List<ConstraintFailure> failures = new ArrayList<>();
+                    JsonToken token = parser.nextToken();
+                    if (token == JsonToken.VALUE_NULL) {
+                        break;
+                    } else if (token == JsonToken.START_ARRAY) {
+                        while (parser.nextToken() == JsonToken.START_OBJECT) {
+                            failures.add(ConstraintFailure.parse(parser));
+                        }
+                        break;
+                    } else {
+                        throw new ClientException("Unexpected for constraint failures: " + token);
+                    }
+            }
+        }
+        return builder.build();
+    }
 
     public String getCode() {
         return code;

--- a/src/main/java/com/fauna/response/wire/ErrorInfoWire.java
+++ b/src/main/java/com/fauna/response/wire/ErrorInfoWire.java
@@ -1,20 +1,11 @@
 package com.fauna.response.wire;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fauna.codec.json.PassThroughDeserializer;
-import com.fauna.exception.ClientException;
 import com.fauna.response.ConstraintFailure;
 
-import static com.fauna.constants.ResponseFields.ERROR_CODE_FIELD_NAME;
-import static com.fauna.constants.ResponseFields.ERROR_CONSTRAINT_FAILURES_FIELD_NAME;
-import static com.fauna.constants.ResponseFields.ERROR_MESSAGE_FIELD_NAME;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -43,70 +34,7 @@ public class ErrorInfoWire {
         this.message = message;
     }
 
-    public static class Builder {
-        String code = null;
-        String message = "";
-        ConstraintFailureWire[] constraintFailures = null;
-        String abort = null;
 
-        public Builder code(String code) {
-            this.code = code;
-            return this;
-        }
-
-        public Builder message(String message) {
-            this.message = message;
-            return this;
-        }
-
-        public Builder abort(Object abort) {
-            this.abort = abort.toString();
-            return this;
-        }
-
-        public ErrorInfoWire build() {
-            return new ErrorInfoWire(this.code, this.message, this.constraintFailures, "abort parsing not implemented");
-        }
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static ErrorInfoWire parse(JsonParser parser) throws IOException {
-        if (parser.nextToken() != JsonToken.START_OBJECT) {
-            throw new ClientException("Error parsing error info, got token" + parser.currentToken());
-        }
-        Builder builder = ErrorInfoWire.builder();
-
-        while (parser.nextToken() != JsonToken.FIELD_NAME) {
-            String fieldName = parser.getCurrentName();
-            switch (fieldName) {
-                case ERROR_CODE_FIELD_NAME:
-                    parser.nextToken();
-                    builder.code(parser.getText());
-                    break;
-                case ERROR_MESSAGE_FIELD_NAME:
-                    parser.nextToken();
-                    builder.message(parser.getText());
-                    break;
-                case ERROR_CONSTRAINT_FAILURES_FIELD_NAME:
-                    List<ConstraintFailure> failures = new ArrayList<>();
-                    JsonToken token = parser.nextToken();
-                    if (token == JsonToken.VALUE_NULL) {
-                        break;
-                    } else if (token == JsonToken.START_ARRAY) {
-                        while (parser.nextToken() == JsonToken.START_OBJECT) {
-                            failures.add(ConstraintFailure.parse(parser));
-                        }
-                        break;
-                    } else {
-                        throw new ClientException("Unexpected for constraint failures: " + token);
-                    }
-            }
-        }
-        return builder.build();
-    }
 
     public String getCode() {
         return code;
@@ -119,6 +47,19 @@ public class ErrorInfoWire {
     public Optional<ConstraintFailureWire[]> getConstraintFailures() {
         return Optional.ofNullable(constraintFailures);
     }
+
+    public Optional<ConstraintFailure[]> getConstraintFailureArray() {
+        if (constraintFailures == null) {
+            return Optional.empty();
+        } else {
+            ConstraintFailure[] failures = new ConstraintFailure[constraintFailures.length];
+            for (int i = 0; i < constraintFailures.length; i++) {
+                failures[i] = this.constraintFailures[i].toConstraintFailure();
+            }
+            return Optional.of(failures);
+        }
+    }
+
 
     public Optional<String> getAbort() {
         return Optional.ofNullable(this.abort);

--- a/src/test/java/com/fauna/e2e/E2EConstraintTest.java
+++ b/src/test/java/com/fauna/e2e/E2EConstraintTest.java
@@ -34,7 +34,7 @@ public class E2EConstraintTest {
         ConstraintFailure actual = exc.getConstraintFailures().get(0);
         assertEquals("Document failed check constraint `posQuantity`", actual.getMessage());
         assertTrue(actual.getName().isEmpty());
-        assertEquals(0, actual.getPaths().size());
+        assertEquals(0, actual.getPaths().length);
     }
 
     @Test
@@ -49,7 +49,7 @@ public class E2EConstraintTest {
         assertTrue(actual.getName().isEmpty());
 
         var paths = actual.getPaths();
-        assertEquals(1, paths.size());
-        assertEquals(List.of("name"), paths.get(0));
+        assertEquals(1, paths.length);
+        assertEquals(new ConstraintFailure.PathElement[]{new ConstraintFailure.PathElement("foo")}, paths[0]);
     }
 }

--- a/src/test/java/com/fauna/e2e/E2EConstraintTest.java
+++ b/src/test/java/com/fauna/e2e/E2EConstraintTest.java
@@ -34,7 +34,7 @@ public class E2EConstraintTest {
         ConstraintFailure actual = exc.getConstraintFailures().get(0);
         assertEquals("Document failed check constraint `posQuantity`", actual.getMessage());
         assertTrue(actual.getName().isEmpty());
-        assertEquals(0, actual.getPaths().length);
+        assertEquals(0, actual.getPaths().get().length);
     }
 
     @Test
@@ -48,8 +48,8 @@ public class E2EConstraintTest {
         assertEquals("Failed unique constraint", actual.getMessage());
         assertTrue(actual.getName().isEmpty());
 
-        var paths = actual.getPaths();
+        ConstraintFailure.PathElement[][] paths = actual.getPaths().get();
         assertEquals(1, paths.length);
-        assertEquals(new ConstraintFailure.PathElement[]{new ConstraintFailure.PathElement("foo")}, paths[0]);
+        assertEquals(List.of("name"), actual.getPathStrings().orElseThrow());
     }
 }

--- a/src/test/java/com/fauna/e2e/E2EErrorHandlingTest.java
+++ b/src/test/java/com/fauna/e2e/E2EErrorHandlingTest.java
@@ -2,12 +2,15 @@ package com.fauna.e2e;
 
 import com.fauna.client.Fauna;
 import com.fauna.client.FaunaClient;
+import com.fauna.exception.AbortException;
 import com.fauna.exception.ConstraintFailureException;
 import com.fauna.response.ConstraintFailure;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -18,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class E2EConstraintTest {
+public class E2EErrorHandlingTest {
     public static final FaunaClient client = Fauna.local();
 
     @BeforeAll
@@ -51,5 +54,23 @@ public class E2EConstraintTest {
         ConstraintFailure.PathElement[][] paths = actual.getPaths().get();
         assertEquals(1, paths.length);
         assertEquals(List.of("name"), actual.getPathStrings().orElseThrow());
+    }
+
+    @Test
+    @Disabled
+    public void constraintFailureWithInteger() throws IOException {
+        // TODO: This throws an error while parsing, will fix in next PR.
+        ConstraintFailureException exc = assertThrows(ConstraintFailureException.class, () -> client.query(
+                fql("Collection.create({name: \"Foo\", constraints: [{unique: [\"$$$\"] }]})")));
+        assertEquals(exc.getConstraintFailures().size(), 2);
+    }
+
+    @Test
+    public void testAbortAPI() throws IOException {
+        Instant bigBang = Instant.parse("2019-12-31T23:59:59.999Z");
+        AbortException exc = assertThrows(AbortException.class, () -> client.query(fql("abort(${bigBang})", Map.of("bigBang", bigBang))));
+        assertEquals(999000000, exc.getAbort(Instant.class).getNano());
+        assertEquals(Instant.class, exc.getAbort().getClass());
+        assertEquals(999000000, ((Instant) exc.getAbort()).getNano());
     }
 }

--- a/src/test/java/com/fauna/exception/ConstraintFailureTest.java
+++ b/src/test/java/com/fauna/exception/ConstraintFailureTest.java
@@ -1,13 +1,17 @@
 package com.fauna.exception;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fauna.response.ConstraintFailure;
+import com.fauna.response.ConstraintFailure.PathElement;
 import com.fauna.response.QueryStats;
 import com.fauna.response.wire.QueryResponseWire;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 import static com.fauna.exception.ErrorHandler.handleErrorResponse;
@@ -16,21 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConstraintFailureTest {
     ObjectMapper mapper = new ObjectMapper();
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
-    private QueryResponseWire getQueryResponseWire(List<List<Object>> paths) throws JsonProcessingException {
-        ObjectNode body = mapper.createObjectNode();
-        QueryStats stats = new QueryStats(0, 0, 0, 0, 0, 0, 0, 0, List.of());
-        // body.put("stats", mapper.writeValueAsString(stats));
-        body.putPOJO("stats", stats);
-        body.put("summary", "error: failed to...");
-        body.put("txn_ts", 1723490275035000L);
-        body.put("schema_version", 1723490246890000L);
-        ObjectNode error = body.putObject("error");
-        error.put("code", "constraint_failure");
-        error.put("message", "Failed to create... ");
-
-        ArrayNode failures = error.putArray("constraint_failures");
-        ObjectNode failure = failures.addObject();
+    private ObjectNode constraintFailure(List<List<Object>> paths) {
+        ObjectNode failure = mapper.createObjectNode();
         ArrayNode pathArray = failure.putArray("paths");
         for (List<Object> path : paths) {
             ArrayNode pathNode = mapper.createArrayNode();
@@ -46,13 +39,40 @@ public class ConstraintFailureTest {
             pathArray.add(pathNode);
         }
         failure.put("message", "Document failed check constraint");
-        return mapper.readValue(body.toString(), QueryResponseWire.class);
+        return failure;
+    }
+
+    private String getQueryResponseWire(List<List<Object>> paths) {
+        ObjectNode body = mapper.createObjectNode();
+        QueryStats stats = new QueryStats(0, 0, 0, 0, 0, 0, 0, 0, List.of());
+        // body.put("stats", mapper.writeValueAsString(stats));
+        body.putPOJO("stats", stats);
+        body.put("summary", "error: failed to...");
+        body.put("txn_ts", 1723490275035000L);
+        body.put("schema_version", 1723490246890000L);
+        ObjectNode error = body.putObject("error");
+        error.put("code", "constraint_failure");
+        error.put("message", "Failed to create... ");
+        ArrayNode failures = error.putArray("constraint_failures");
+        failures.add(constraintFailure(paths));
+        return body.toString();
+    }
+
+    @Test
+    public void TestConstraintFailureFromBodyUsingParser() throws IOException {
+        String failureWire = constraintFailure(List.of(List.of("pathElement"))).toString();
+        ConstraintFailure failure = ConstraintFailure.parse(JSON_FACTORY.createParser(failureWire));
+        ConstraintFailure.PathElement[][] actualFailures = failure.getPaths().get();
+        assertEquals(new PathElement[]{new PathElement("hello")}, actualFailures);
+
     }
 
     @Test
     public void TestConstraintFailureFromBodyWithPath() throws JsonProcessingException {
         List<List<Object>> expected = List.of(List.of("name"));
-        var res = getQueryResponseWire(expected);
+
+        String body = getQueryResponseWire(expected);
+        QueryResponseWire res = mapper.readValue(body, QueryResponseWire.class);
         ConstraintFailureException exc = assertThrows(ConstraintFailureException.class, () -> handleErrorResponse(400, res, ""));
         assertEquals(expected, exc.getConstraintFailures().get(0).getPaths());
     }
@@ -60,7 +80,8 @@ public class ConstraintFailureTest {
     @Test
     public void TestConstraintFailureFromBodyWithIntegerInPath() throws JsonProcessingException {
         List<List<Object>> expected = List.of(List.of("name"), List.of("name2", 1, 2, "name3"));
-        var res = getQueryResponseWire(expected);
+        String body = getQueryResponseWire(expected);
+        QueryResponseWire res = mapper.readValue(body, QueryResponseWire.class);
         ConstraintFailureException exc = assertThrows(ConstraintFailureException.class, () -> handleErrorResponse(400, res, ""));
         assertEquals(expected, exc.getConstraintFailures().get(0).getPaths());
     }

--- a/src/test/java/com/fauna/exception/ErrorInfoTest.java
+++ b/src/test/java/com/fauna/exception/ErrorInfoTest.java
@@ -1,15 +1,20 @@
 package com.fauna.exception;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import com.fauna.codec.Codec;
+import com.fauna.codec.DefaultCodecProvider;
+import com.fauna.codec.UTF8FaunaParser;
 import com.fauna.response.ConstraintFailure;
 import com.fauna.response.ErrorInfo;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -28,23 +33,61 @@ public class ErrorInfoTest {
         return paths;
     }
 
-    public ObjectNode buildConstraintFailureError() {
+    public ObjectNode buildError(String code, String message) {
         ObjectNode infoJson = MAPPER.createObjectNode();
-        infoJson.put("code", "constraint_failure");
-        infoJson.put("message", "Constraint Failure.");
+        infoJson.put("code", code);
+        infoJson.put("message", message);
         return infoJson;
     }
 
     @Test
-    public void testParseWithMinimalConstraintFailure() throws IOException {
+    public void testParseSimpleError() throws IOException {
+        ObjectNode errorJson = buildError("invalid_request", "Invalid Request!");
+        ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(errorJson.toString()));
+        assertEquals("invalid_request", info.getCode());
+        assertEquals("Invalid Request!", info.getMessage());
+        assertTrue(info.getAbort(null).isEmpty());
+        assertTrue(info.getAbortJson().isEmpty());
+        assertTrue(info.getConstraintFailures().isEmpty());
+    }
 
-        ObjectNode infoJson = buildConstraintFailureError();
+    @Test
+    public void testParseWithAbortData() throws IOException {
+        ObjectNode infoJson = buildError("abort", "aborted!");
+        ObjectNode abortData = infoJson.putObject("abort");
+        abortData.put("@time", "2023-04-06T03:33:32.226Z");
+        ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(infoJson.toString()));
+        assertEquals("abort", info.getCode());
+        TreeNode tree = info.getAbortJson().get();
+        UTF8FaunaParser parser = new UTF8FaunaParser(tree.traverse());
+        Codec<Instant> instantCodec = DefaultCodecProvider.SINGLETON.get(Instant.class);
+        parser.read();
+        Instant abortTime = instantCodec.decode(parser);
+        assertEquals(1680752012226L, abortTime.toEpochMilli());
+    }
+
+    @Test
+    public void testParseAndGetAbortData() throws IOException {
+        ObjectNode infoJson = buildError("abort", "aborted!");
+        ObjectNode abortData = infoJson.putObject("abort");
+        abortData.put("@time", "2023-04-06T03:33:32.226Z");
+        ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(infoJson.toString()));
+        assertEquals("abort", info.getCode());
+        Instant abortTime = info.getAbort(Instant.class).get();
+        assertEquals(1680752012226L, abortTime.toEpochMilli());
+    }
+
+    @Test
+    public void testParseWithMinimalConstraintFailure() throws IOException {
+        ObjectNode infoJson = buildError("constraint_failure", "Constraint failed!");
         ArrayNode failures = infoJson.putArray("constraint_failures");
         ObjectNode failure1 = failures.addObject();
         failure1.put("message", "msg1");
 
         ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(infoJson.toString()));
-        assertEquals("Constraint Failure.", info.getMessage());
+        assertTrue(info.getAbortJson().isEmpty());
+        assertTrue(info.getAbort(String.class).isEmpty());
+        assertEquals("Constraint failed!", info.getMessage());
         assertEquals("constraint_failure", info.getCode());
         assertTrue(info.getConstraintFailures().isPresent());
         assertEquals(1, info.getConstraintFailures().orElseThrow().length);
@@ -56,8 +99,7 @@ public class ErrorInfoTest {
 
     @Test
     public void testParseWithMultipleConstraintFailures() throws IOException {
-
-        ObjectNode infoJson = buildConstraintFailureError();
+        ObjectNode infoJson = buildError("constraint_failure", "Constraint failed!");
         ArrayNode failures = infoJson.putArray("constraint_failures");
         ObjectNode obj1 = failures.addObject();
         obj1.put("message", "msg1");
@@ -66,7 +108,7 @@ public class ErrorInfoTest {
         obj2.put("message", "msg2");
 
         ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(infoJson.toString()));
-        assertEquals("Constraint Failure.", info.getMessage());
+        assertEquals("Constraint failed!", info.getMessage());
         assertEquals("constraint_failure", info.getCode());
         assertTrue(info.getConstraintFailures().isPresent());
         assertEquals(2, info.getConstraintFailures().orElseThrow().length);
@@ -83,8 +125,7 @@ public class ErrorInfoTest {
 
     @Test
     public void testParseWithConstraintFailuresWithPaths() throws IOException {
-
-        ObjectNode infoJson = buildConstraintFailureError();
+        ObjectNode infoJson = buildError("constraint_failure", "Constraint failed!");
         ArrayNode failures = infoJson.putArray("constraint_failures");
         ObjectNode obj1 = failures.addObject();
         obj1.put("message", "msg1");
@@ -95,7 +136,7 @@ public class ErrorInfoTest {
         addPaths(obj2, List.of(List.of(2, "a")));
 
         ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(infoJson.toString()));
-        assertEquals("Constraint Failure.", info.getMessage());
+        assertEquals("Constraint failed!", info.getMessage());
         assertEquals("constraint_failure", info.getCode());
         assertTrue(info.getConstraintFailures().isPresent());
         assertEquals(2, info.getConstraintFailures().orElseThrow().length);

--- a/src/test/java/com/fauna/exception/ErrorInfoTest.java
+++ b/src/test/java/com/fauna/exception/ErrorInfoTest.java
@@ -1,0 +1,114 @@
+package com.fauna.exception;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import com.fauna.response.ConstraintFailure;
+import com.fauna.response.ErrorInfo;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ErrorInfoTest {
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+    private static final ObjectMapper MAPPER = new ObjectMapper(JSON_FACTORY);
+
+    public ArrayNode addPaths(ObjectNode failure, List<List<Object>> elements) {
+        ArrayNode paths = failure.putArray("paths");
+        for (List<Object> pathElements : elements) {
+            ArrayNode path = paths.addArray();
+            pathElements.forEach(e -> path.add(e.toString()));
+        }
+        return paths;
+    }
+
+    public ObjectNode buildConstraintFailureError() {
+        ObjectNode infoJson = MAPPER.createObjectNode();
+        infoJson.put("code", "constraint_failure");
+        infoJson.put("message", "Constraint Failure.");
+        return infoJson;
+    }
+
+    @Test
+    public void testParseWithMinimalConstraintFailure() throws IOException {
+
+        ObjectNode infoJson = buildConstraintFailureError();
+        ArrayNode failures = infoJson.putArray("constraint_failures");
+        ObjectNode failure1 = failures.addObject();
+        failure1.put("message", "msg1");
+
+        ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(infoJson.toString()));
+        assertEquals("Constraint Failure.", info.getMessage());
+        assertEquals("constraint_failure", info.getCode());
+        assertTrue(info.getConstraintFailures().isPresent());
+        assertEquals(1, info.getConstraintFailures().orElseThrow().length);
+        ConstraintFailure constraintFailure = info.getConstraintFailures().get()[0];
+        assertEquals("msg1", constraintFailure.getMessage());
+        assertTrue(constraintFailure.getName().isEmpty());
+        assertTrue(constraintFailure.getPaths().isEmpty());
+    }
+
+    @Test
+    public void testParseWithMultipleConstraintFailures() throws IOException {
+
+        ObjectNode infoJson = buildConstraintFailureError();
+        ArrayNode failures = infoJson.putArray("constraint_failures");
+        ObjectNode obj1 = failures.addObject();
+        obj1.put("message", "msg1");
+        obj1.put("name", "name1");
+        ObjectNode obj2 = failures.addObject();
+        obj2.put("message", "msg2");
+
+        ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(infoJson.toString()));
+        assertEquals("Constraint Failure.", info.getMessage());
+        assertEquals("constraint_failure", info.getCode());
+        assertTrue(info.getConstraintFailures().isPresent());
+        assertEquals(2, info.getConstraintFailures().orElseThrow().length);
+        ConstraintFailure constraintFailure = info.getConstraintFailures().get()[0];
+        assertEquals("msg1", constraintFailure.getMessage());
+        assertEquals("name1", constraintFailure.getName().orElseThrow());
+        assertTrue(constraintFailure.getPaths().isEmpty());
+
+        ConstraintFailure failure2 = info.getConstraintFailures().get()[1];
+        assertEquals("msg2", failure2.getMessage());
+        assertTrue(failure2.getName().isEmpty());
+        assertTrue(failure2.getPaths().isEmpty());
+    }
+
+    @Test
+    public void testParseWithConstraintFailuresWithPaths() throws IOException {
+
+        ObjectNode infoJson = buildConstraintFailureError();
+        ArrayNode failures = infoJson.putArray("constraint_failures");
+        ObjectNode obj1 = failures.addObject();
+        obj1.put("message", "msg1");
+        addPaths(obj1, List.of(List.of(1, "a"), List.of("1b")));
+
+        ObjectNode obj2 = failures.addObject();
+        obj2.put("message", "msg2");
+        addPaths(obj2, List.of(List.of(2, "a")));
+
+        ErrorInfo info = ErrorInfo.parse(JSON_FACTORY.createParser(infoJson.toString()));
+        assertEquals("Constraint Failure.", info.getMessage());
+        assertEquals("constraint_failure", info.getCode());
+        assertTrue(info.getConstraintFailures().isPresent());
+        assertEquals(2, info.getConstraintFailures().orElseThrow().length);
+        ConstraintFailure failure1 = info.getConstraintFailures().get()[0];
+        assertTrue(failure1.getPaths().isPresent());
+        assertEquals("msg1", failure1.getMessage());
+        assertTrue(failure1.getName().isEmpty());
+        assertEquals(List.of("1.a", "1b"), failure1.getPathStrings().orElseThrow());
+
+        ConstraintFailure failure2 = info.getConstraintFailures().get()[1];
+        assertEquals("msg2", failure2.getMessage());
+        assertTrue(failure2.getName().isEmpty());
+        assertEquals(List.of("2.a"), failure2.getPathStrings().orElseThrow());
+    }
+
+}

--- a/src/test/java/com/fauna/exception/TestServiceException.java
+++ b/src/test/java/com/fauna/exception/TestServiceException.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,7 +29,7 @@ public class TestServiceException {
         root.put("summary", "summarized");
         root.put("schema_version", 10);
         root.put("query_tags", "foo=bar");
-        root.put("txn_ts", Long.MAX_VALUE / 4); // would cause int overflow
+        root.put("txn_ts", Long.MAX_VALUE / 4); // MAX_VALUE would cause overflow
 
         ObjectNode error = root.putObject("error");
         error.put("code", "bad_thing");
@@ -37,7 +38,7 @@ public class TestServiceException {
         ObjectNode stats = root.putObject("stats");
         stats.put("compute_ops", 100);
 
-        var res = mapper.readValue(root.toString(), QueryResponseWire.class);
+        QueryResponseWire res = mapper.readValue(root.toString(), QueryResponseWire.class);
         QueryFailure failure = new QueryFailure(500, res);
 
         // When
@@ -50,7 +51,7 @@ public class TestServiceException {
         assertEquals("summarized", exc.getSummary());
         assertEquals(100, exc.getStats().computeOps);
         assertEquals(10, exc.getSchemaVersion());
-        assertEquals(Long.MAX_VALUE / 4, exc.getTxnTs());
+        assertEquals(Optional.of(Long.MAX_VALUE / 4), exc.getTxnTs());
         assertEquals(Map.of("foo", "bar"), exc.getQueryTags());
 
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
This change is a step in the direction of getting rid of ObjectMapper so we can just directly use `JsonParser/UTF8FaunaParser` on the responses, so we never have to call `toString()`. In the long run this should be better, but this PR probably doesn't materially improve things from the users perspective.

I created task: https://faunadb.atlassian.net/browse/BT-5119 

### Motivation and context
We have what Lucas described as a 'Layer cake' in the response handling, and this goes part of the way to removing that.

### How was the change tested?
Unit and E2E tests.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.