### PR TITLE
[audit-todos] Address TODO by setting two headers

### DIFF
--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -47,7 +47,7 @@ public abstract class FaunaClient {
     }
 
     public Optional<Long> getLastTransactionTs() {
-        Long ts = lastTransactionTs.get();
+        long ts = lastTransactionTs.get();
         return ts > 0 ? Optional.of(ts) : Optional.empty();
     }
 
@@ -70,14 +70,12 @@ public abstract class FaunaClient {
         }
     }
 
-    private <T> QuerySuccess<T> completeRequest(QuerySuccess<T> success, Throwable throwable) {
+    private <T> void completeRequest(QuerySuccess<T> success, Throwable throwable) {
         if (success != null) {
             updateTs(success);
-            return success;
         } else if (throwable != null) {
             extractServiceException(throwable).ifPresent(exc -> updateTs(exc.getResponse()));
         }
-        return null;
     }
 
     //region Asynchronous API

--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -51,8 +51,8 @@ public abstract class FaunaClient {
         return ts > 0 ? Optional.of(ts) : Optional.empty();
     }
 
-    private static <T> Supplier<CompletableFuture<QuerySuccess<T>>> makeAsyncRequest(HttpClient client, HttpRequest request, Codec<T> codec) {
-        return () -> client.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream()).thenApply(body -> QueryResponse.parseResponse(body, codec));
+    private <T> Supplier<CompletableFuture<QuerySuccess<T>>> makeAsyncRequest(HttpClient client, HttpRequest request, Codec<T> codec) {
+        return () -> client.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream()).thenApply(body -> QueryResponse.parseResponse(body, codec)).whenComplete(this::completeRequest);
     }
 
     private static Optional<ServiceException> extractServiceException(Throwable throwable) {
@@ -95,8 +95,8 @@ public abstract class FaunaClient {
             throw new IllegalArgumentException("The provided FQL query is null.");
         }
         Codec<Object> codec = codecProvider.get(Object.class, null);
-        return new RetryHandler<QuerySuccess<Object>>(getRetryStrategy()).execute(FaunaClient.makeAsyncRequest(
-                getHttpClient(), getRequestBuilder().buildRequest(fql, null, codecProvider, lastTransactionTs.get()), codec)).whenComplete(this::completeRequest);
+        return new RetryHandler<QuerySuccess<Object>>(getRetryStrategy()).execute(makeAsyncRequest(
+                getHttpClient(), getRequestBuilder().buildRequest(fql, null, codecProvider, lastTransactionTs.get()), codec));
     }
 
     /**
@@ -117,8 +117,8 @@ public abstract class FaunaClient {
             throw new IllegalArgumentException("The provided FQL query is null.");
         }
         Codec<T> codec = codecProvider.get(resultClass, null);
-        return new RetryHandler<QuerySuccess<T>>(getRetryStrategy()).execute(FaunaClient.makeAsyncRequest(
-                getHttpClient(), getRequestBuilder().buildRequest(fql, options, codecProvider, lastTransactionTs.get()), codec)).whenComplete(this::completeRequest);
+        return new RetryHandler<QuerySuccess<T>>(getRetryStrategy()).execute(makeAsyncRequest(
+                getHttpClient(), getRequestBuilder().buildRequest(fql, options, codecProvider, lastTransactionTs.get()), codec));
     }
 
     /**
@@ -140,8 +140,8 @@ public abstract class FaunaClient {
         }
         @SuppressWarnings("unchecked")
         Codec<E> codec = codecProvider.get((Class<E>) parameterizedType.getRawType(), parameterizedType.getActualTypeArguments());
-        return new RetryHandler<QuerySuccess<E>>(getRetryStrategy()).execute(FaunaClient.makeAsyncRequest(
-                getHttpClient(), getRequestBuilder().buildRequest(fql, options, codecProvider, lastTransactionTs.get()), codec)).whenComplete(this::completeRequest);
+        return new RetryHandler<QuerySuccess<E>>(getRetryStrategy()).execute(makeAsyncRequest(
+                getHttpClient(), getRequestBuilder().buildRequest(fql, options, codecProvider, lastTransactionTs.get()), codec));
     }
 
     /**
@@ -178,8 +178,8 @@ public abstract class FaunaClient {
         }
         @SuppressWarnings("unchecked")
         Codec<E> codec = codecProvider.get((Class<E>) parameterizedType.getRawType(), parameterizedType.getActualTypeArguments());
-        return new RetryHandler<QuerySuccess<E>>(getRetryStrategy()).execute(FaunaClient.makeAsyncRequest(
-                getHttpClient(), getRequestBuilder().buildRequest(fql, null, codecProvider, lastTransactionTs.get()), codec)).whenComplete(this::completeRequest);
+        return new RetryHandler<QuerySuccess<E>>(getRetryStrategy()).execute(makeAsyncRequest(
+                getHttpClient(), getRequestBuilder().buildRequest(fql, null, codecProvider, lastTransactionTs.get()), codec));
     }
     //endregion
 

--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -56,7 +56,7 @@ public abstract class FaunaClient {
     }
 
     private static Optional<ServiceException> extractServiceException(Throwable throwable) {
-        if (throwable.getCause() instanceof FaunaException) {
+        if (throwable.getCause() instanceof ServiceException) {
             return Optional.of((ServiceException) throwable.getCause());
         } else {
             return Optional.empty();

--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -51,10 +51,6 @@ public abstract class FaunaClient {
         return ts > 0 ? Optional.of(ts) : Optional.empty();
     }
 
-    private <T> Supplier<CompletableFuture<QuerySuccess<T>>> makeAsyncRequest(HttpClient client, HttpRequest request, Codec<T> codec) {
-        return () -> client.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream()).thenApply(body -> QueryResponse.parseResponse(body, codec)).whenComplete(this::completeRequest);
-    }
-
     private static Optional<ServiceException> extractServiceException(Throwable throwable) {
         if (throwable.getCause() instanceof ServiceException) {
             return Optional.of((ServiceException) throwable.getCause());
@@ -77,6 +73,11 @@ public abstract class FaunaClient {
             extractServiceException(throwable).ifPresent(exc -> updateTs(exc.getResponse()));
         }
     }
+
+    private <T> Supplier<CompletableFuture<QuerySuccess<T>>> makeAsyncRequest(HttpClient client, HttpRequest request, Codec<T> codec) {
+        return () -> client.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream()).thenApply(body -> QueryResponse.parseResponse(body, codec)).whenComplete(this::completeRequest);
+    }
+
 
     //region Asynchronous API
     /**

--- a/src/main/java/com/fauna/client/FaunaConfig.java
+++ b/src/main/java/com/fauna/client/FaunaConfig.java
@@ -16,6 +16,7 @@ public class FaunaConfig {
 
     private final String endpoint;
     private final String secret;
+    private final int maxContentionRetries;
     public static final FaunaConfig DEFAULT = FaunaConfig.builder().build();
     public static final FaunaConfig LOCAL = FaunaConfig.builder().endpoint(
             FaunaEndpoint.LOCAL).secret("secret").build();
@@ -28,6 +29,7 @@ public class FaunaConfig {
     private FaunaConfig(Builder builder) {
         this.endpoint = builder.endpoint != null ? builder.endpoint : FaunaEndpoint.DEFAULT;
         this.secret = builder.secret != null ? builder.secret : "";
+        this.maxContentionRetries = builder.maxContentionRetries;
     }
 
     /**
@@ -50,6 +52,15 @@ public class FaunaConfig {
     }
 
     /**
+     * Gets the number of contention retries that the Fauna server will attempt.
+     * @return  An integer value.
+     */
+    public int getMaxContentionRetries() {
+        return maxContentionRetries;
+    }
+
+
+    /**
      * Creates a new builder for FaunaConfig.
      *
      * @return A new instance of Builder.
@@ -64,6 +75,7 @@ public class FaunaConfig {
     public static class Builder {
         private String endpoint = null;
         private String secret = null;
+        private int maxContentionRetries = 3;
 
         /**
          * Sets the endpoint URL.
@@ -84,6 +96,11 @@ public class FaunaConfig {
          */
         public Builder secret(String secret) {
             this.secret = secret;
+            return this;
+        }
+
+        public Builder maxContentionRetries(int maxContentionRetries) {
+            this.maxContentionRetries = maxContentionRetries;
             return this;
         }
 

--- a/src/main/java/com/fauna/client/RequestBuilder.java
+++ b/src/main/java/com/fauna/client/RequestBuilder.java
@@ -140,7 +140,7 @@ public class RequestBuilder {
      * Get either the base request builder (if options is null) or a copy with the options applied.
      * @param options The QueryOptions (must not be null).
      */
-    private HttpRequest.Builder getBuilder(QueryOptions options, Long last_txn_ts) {
+    private HttpRequest.Builder getBuilder(QueryOptions options, Long lastTxnTs) {
         if (options == null && (last_txn_ts == null || last_txn_ts <= 0) ) {
             return baseRequestBuilder;
         }

--- a/src/main/java/com/fauna/client/RequestBuilder.java
+++ b/src/main/java/com/fauna/client/RequestBuilder.java
@@ -51,7 +51,7 @@ public class RequestBuilder {
         static final String FORMAT = "X-Format";
     }
 
-    public RequestBuilder(URI uri, String token) {
+    public RequestBuilder(URI uri, String token, int max_contention_retries) {
         // DriverEnvironment is not needed outside the constructor for now.
         DriverEnvironment env = new DriverEnvironment(DriverEnvironment.JvmDriver.JAVA);
         this.baseRequestBuilder = HttpRequest.newBuilder().uri(uri).headers(
@@ -60,6 +60,7 @@ public class RequestBuilder {
                 RequestBuilder.Headers.CONTENT_TYPE, "application/json;charset=utf-8",
                 RequestBuilder.Headers.DRIVER, "Java",
                 RequestBuilder.Headers.DRIVER_ENV, env.toString(),
+                RequestBuilder.Headers.MAX_CONTENTION_RETRIES, String.valueOf(max_contention_retries),
                 Headers.AUTHORIZATION, buildAuthHeader(token)
         );
     }
@@ -69,11 +70,11 @@ public class RequestBuilder {
     }
 
     public static RequestBuilder queryRequestBuilder(FaunaConfig config) {
-        return new RequestBuilder(URI.create(config.getEndpoint() + QUERY_PATH), config.getSecret());
+        return new RequestBuilder(URI.create(config.getEndpoint() + QUERY_PATH), config.getSecret(), config.getMaxContentionRetries());
     }
 
     public static RequestBuilder streamRequestBuilder(FaunaConfig config) {
-        return new RequestBuilder(URI.create(config.getEndpoint() + STREAM_PATH), config.getSecret());
+        return new RequestBuilder(URI.create(config.getEndpoint() + STREAM_PATH), config.getSecret(), config.getMaxContentionRetries());
     }
 
     public RequestBuilder scopedRequestBuilder(String token) {

--- a/src/main/java/com/fauna/client/RequestBuilder.java
+++ b/src/main/java/com/fauna/client/RequestBuilder.java
@@ -51,7 +51,7 @@ public class RequestBuilder {
         static final String FORMAT = "X-Format";
     }
 
-    public RequestBuilder(URI uri, String token, int max_contention_retries) {
+    public RequestBuilder(URI uri, String token, int maxContentionRetries) {
         // DriverEnvironment is not needed outside the constructor for now.
         DriverEnvironment env = new DriverEnvironment(DriverEnvironment.JvmDriver.JAVA);
         this.baseRequestBuilder = HttpRequest.newBuilder().uri(uri).headers(

--- a/src/main/java/com/fauna/client/RequestBuilder.java
+++ b/src/main/java/com/fauna/client/RequestBuilder.java
@@ -60,7 +60,7 @@ public class RequestBuilder {
                 RequestBuilder.Headers.CONTENT_TYPE, "application/json;charset=utf-8",
                 RequestBuilder.Headers.DRIVER, "Java",
                 RequestBuilder.Headers.DRIVER_ENV, env.toString(),
-                RequestBuilder.Headers.MAX_CONTENTION_RETRIES, String.valueOf(max_contention_retries),
+                RequestBuilder.Headers.MAX_CONTENTION_RETRIES, String.valueOf(maxContentionRetries),
                 Headers.AUTHORIZATION, buildAuthHeader(token)
         );
     }
@@ -141,12 +141,12 @@ public class RequestBuilder {
      * @param options The QueryOptions (must not be null).
      */
     private HttpRequest.Builder getBuilder(QueryOptions options, Long lastTxnTs) {
-        if (options == null && (last_txn_ts == null || last_txn_ts <= 0) ) {
+        if (options == null && (lastTxnTs == null || lastTxnTs <= 0) ) {
             return baseRequestBuilder;
         }
         HttpRequest.Builder builder = baseRequestBuilder.copy();
-        if (last_txn_ts != null) {
-            builder.setHeader(Headers.LAST_TXN_TS, String.valueOf(last_txn_ts));
+        if (lastTxnTs != null) {
+            builder.setHeader(Headers.LAST_TXN_TS, String.valueOf(lastTxnTs));
         }
         if (options != null) {
             options.getTimeoutMillis().ifPresent(val -> builder.header(Headers.QUERY_TIMEOUT_MS, String.valueOf(val)));

--- a/src/main/java/com/fauna/response/QueryResponse.java
+++ b/src/main/java/com/fauna/response/QueryResponse.java
@@ -137,15 +137,16 @@ public abstract class QueryResponse {
 
     public static <T>  QuerySuccess<T> parseResponse(HttpResponse<InputStream> response, Codec<T> codec) throws FaunaException {
         try {
-                JsonParser parser = JSON_FACTORY.createParser(response.body());
-                JsonToken firstToken = parser.nextToken();
-                Builder<T> builder = QueryResponse.builder(codec);
-                if (firstToken != JsonToken.START_OBJECT) {
-                    throw new ClientResponseException("Response must be JSON object.");
-                }
-                while (parser.nextToken() == JsonToken.FIELD_NAME) {
-                    builder = handleField(builder, parser);
-                }
+            JsonParser parser = JSON_FACTORY.createParser(response.body());
+
+            JsonToken firstToken = parser.nextToken();
+            Builder<T> builder = QueryResponse.builder(codec);
+            if (firstToken != JsonToken.START_OBJECT) {
+                throw new ClientResponseException("Response must be JSON object.");
+            }
+            while (parser.nextToken() == JsonToken.FIELD_NAME) {
+                builder = handleField(builder, parser);
+            }
             int httpStatus = response.statusCode();
             if (httpStatus >= 400) {
                 QueryFailure failure = new QueryFailure(httpStatus, builder);

--- a/src/test/java/com/fauna/client/FaunaClientTest.java
+++ b/src/test/java/com/fauna/client/FaunaClientTest.java
@@ -80,7 +80,7 @@ class FaunaClientTest {
         assertTrue(client.getHttpClient().connectTimeout().isEmpty());
         assertEquals(URI.create("https://db.fauna.com/query/1"),
                 client.getRequestBuilder().buildRequest(
-                        fql("hello"), QueryOptions.builder().build(), DefaultCodecProvider.SINGLETON).uri());
+                        fql("hello"), QueryOptions.builder().build(), DefaultCodecProvider.SINGLETON, 1L).uri());
     }
 
     @Test

--- a/src/test/java/com/fauna/client/RequestBuilderTest.java
+++ b/src/test/java/com/fauna/client/RequestBuilderTest.java
@@ -22,6 +22,7 @@ import java.util.stream.IntStream;
 import static com.fauna.client.RequestBuilder.Headers.AUTHORIZATION;
 import static com.fauna.client.RequestBuilder.Headers.DRIVER_ENV;
 import static com.fauna.client.RequestBuilder.Headers.LINEARIZED;
+import static com.fauna.client.RequestBuilder.Headers.MAX_CONTENTION_RETRIES;
 import static com.fauna.client.RequestBuilder.Headers.QUERY_TAGS;
 import static com.fauna.client.RequestBuilder.Headers.TRACE_PARENT;
 import static com.fauna.client.RequestBuilder.Headers.TYPE_CHECK;
@@ -54,6 +55,7 @@ class RequestBuilderTest {
         assertTrue(headers.firstValue(DRIVER_ENV).orElse("").contains("driver="));
         assertNotNull(headers.firstValue(AUTHORIZATION));
         assertEquals("Bearer secret", headers.firstValue(AUTHORIZATION).orElseThrow());
+        assertEquals("3", headers.firstValue(MAX_CONTENTION_RETRIES).orElseThrow());
     }
 
     @Test

--- a/src/test/java/com/fauna/client/RequestBuilderTest.java
+++ b/src/test/java/com/fauna/client/RequestBuilderTest.java
@@ -15,7 +15,6 @@ import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -32,7 +31,6 @@ import static com.fauna.client.RequestBuilder.Headers.TYPE_CHECK;
 import static com.fauna.query.builder.Query.fql;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RequestBuilderTest {

--- a/src/test/java/com/fauna/client/RequestBuilderTest.java
+++ b/src/test/java/com/fauna/client/RequestBuilderTest.java
@@ -15,20 +15,24 @@ import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.fauna.client.RequestBuilder.Headers.AUTHORIZATION;
 import static com.fauna.client.RequestBuilder.Headers.DRIVER_ENV;
+import static com.fauna.client.RequestBuilder.Headers.LAST_TXN_TS;
 import static com.fauna.client.RequestBuilder.Headers.LINEARIZED;
 import static com.fauna.client.RequestBuilder.Headers.MAX_CONTENTION_RETRIES;
 import static com.fauna.client.RequestBuilder.Headers.QUERY_TAGS;
+import static com.fauna.client.RequestBuilder.Headers.QUERY_TIMEOUT_MS;
 import static com.fauna.client.RequestBuilder.Headers.TRACE_PARENT;
 import static com.fauna.client.RequestBuilder.Headers.TYPE_CHECK;
 import static com.fauna.query.builder.Query.fql;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RequestBuilderTest {
@@ -45,7 +49,7 @@ class RequestBuilderTest {
 
     @Test
     void buildRequest_shouldConstructCorrectHttpRequest() {
-        HttpRequest httpRequest = requestBuilder.buildRequest(fql("Sample fql query"), null, codecProvider);
+        HttpRequest httpRequest = requestBuilder.buildRequest(fql("Sample fql query"), null, codecProvider, -1L);
 
         assertEquals("http://localhost:8443/query/1", httpRequest.uri().toString());
         assertEquals("POST", httpRequest.method());
@@ -56,6 +60,8 @@ class RequestBuilderTest {
         assertNotNull(headers.firstValue(AUTHORIZATION));
         assertEquals("Bearer secret", headers.firstValue(AUTHORIZATION).orElseThrow());
         assertEquals("3", headers.firstValue(MAX_CONTENTION_RETRIES).orElseThrow());
+        List.of(LINEARIZED, TYPE_CHECK, QUERY_TAGS, LAST_TXN_TS, QUERY_TIMEOUT_MS).forEach(
+                hdr -> assertTrue(headers.firstValue(hdr).isEmpty()));
     }
 
     @Test
@@ -63,13 +69,14 @@ class RequestBuilderTest {
         QueryOptions options = QueryOptions.builder().timeout(Duration.ofSeconds(15))
                 .linearized(true).typeCheck(true).traceParent("traceParent").build();
 
-        HttpRequest httpRequest = requestBuilder.buildRequest(fql("Sample FQL Query"), options, codecProvider);
+        HttpRequest httpRequest = requestBuilder.buildRequest(fql("Sample FQL Query"), options, codecProvider, 1L);
         HttpHeaders headers = httpRequest.headers();
 
         assertEquals("true", headers.firstValue(LINEARIZED).orElseThrow());
         assertEquals("true", headers.firstValue(TYPE_CHECK).orElseThrow());
         assertNotNull(headers.firstValue(QUERY_TAGS));
         assertEquals("traceParent", headers.firstValue(TRACE_PARENT).orElseThrow());
+        assertEquals("1", headers.firstValue(LAST_TXN_TS).orElseThrow());
     }
 
     @Test
@@ -108,7 +115,7 @@ class RequestBuilderTest {
         // This was faster, but now I think it's taking time to do things like create the FaunaRequest object.
         // Being able to build 10k requests per second still seems like reasonable performance.
         IntStream.range(0, 10_000).forEach(i -> requestBuilder.buildRequest(
-                fql("Sample FQL Query ${i}", Map.of("i", i)), null, codecProvider));
+                fql("Sample FQL Query ${i}", Map.of("i", i)), null, codecProvider, 1L));
     }
 
     @Test
@@ -126,6 +133,6 @@ class RequestBuilderTest {
                 .linearized((i+1) % 2 == 0)
                 .build()).collect(Collectors.toList());
         IntStream.range(0, 1_000).forEach(i -> requestBuilder.buildRequest(
-                fql("Sample FQL Query ${i}", Map.of("i", i)), opts.get(i % 100), codecProvider));
+                fql("Sample FQL Query ${i}", Map.of("i", i)), opts.get(i % 100), codecProvider, 1L));
     }
 }

--- a/src/test/java/com/fauna/client/RequestBuilderTest.java
+++ b/src/test/java/com/fauna/client/RequestBuilderTest.java
@@ -1,6 +1,9 @@
 package com.fauna.client;
 
-import com.fauna.codec.*;
+import com.fauna.codec.CodecProvider;
+import com.fauna.codec.CodecRegistry;
+import com.fauna.codec.DefaultCodecProvider;
+import com.fauna.codec.DefaultCodecRegistry;
 import com.fauna.query.QueryOptions;
 import com.fauna.stream.StreamRequest;
 import org.junit.jupiter.api.Test;
@@ -10,9 +13,10 @@ import java.io.IOException;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.fauna.client.RequestBuilder.Headers.AUTHORIZATION;
@@ -30,7 +34,7 @@ class RequestBuilderTest {
 
     private final FaunaConfig faunaConfig = FaunaConfig.builder()
             .endpoint(FaunaConfig.FaunaEndpoint.LOCAL)
-            .secret("secret").build();;
+            .secret("secret").build();
 
     private final RequestBuilder requestBuilder = RequestBuilder.queryRequestBuilder(faunaConfig);
 
@@ -89,7 +93,6 @@ class RequestBuilderTest {
     @Test
     void buildStreamRequestBody_shouldIncludeTimestamp() throws IOException {
         // Given
-        Long timestamp = Long.MAX_VALUE / 2;
         StreamRequest request = new StreamRequest("tkn", Long.MAX_VALUE / 2);
         // When
         String body = requestBuilder.buildStreamRequestBody(request);
@@ -98,11 +101,29 @@ class RequestBuilderTest {
     }
 
     @Test
-    @Timeout(value=1000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(value=1_000, unit = TimeUnit.MILLISECONDS)
     void buildRequest_shouldBeFast() {
         // This was faster, but now I think it's taking time to do things like create the FaunaRequest object.
         // Being able to build 10k requests per second still seems like reasonable performance.
-        IntStream.range(0, 10000).forEach(i -> requestBuilder.buildRequest(
+        IntStream.range(0, 10_000).forEach(i -> requestBuilder.buildRequest(
                 fql("Sample FQL Query ${i}", Map.of("i", i)), null, codecProvider));
+    }
+
+    @Test
+    @Timeout(value=1000, unit = TimeUnit.MILLISECONDS)
+    void buildRequest_withQueryOptions_shouldBeFast() {
+        // I tried implementing a cache in RequestBuilder.java that re-uses the HttpRequest.Builder if the QueryOptions
+        // are identical to a previous request. It wasn't any faster, even for up to 1MM buildRequest iterations. I'm
+        // leaving this test here in case we ever want to prove that requestBuilder is "fast enough".
+        // It takes 90ms on my Mac to build 1k requests. That seems "good enough" for now!
+        List<QueryOptions> opts = IntStream.range(0, 100).mapToObj(i -> QueryOptions.builder()
+                .queryTag("key" + i, String.valueOf(i))
+                .timeout(Duration.ofSeconds(i % 10 ))
+                .traceParent("trace" + i)
+                .typeCheck(i % 2 == 0)
+                .linearized((i+1) % 2 == 0)
+                .build()).collect(Collectors.toList());
+        IntStream.range(0, 1_000).forEach(i -> requestBuilder.buildRequest(
+                fql("Sample FQL Query ${i}", Map.of("i", i)), opts.get(i % 100), codecProvider));
     }
 }

--- a/src/test/java/com/fauna/e2e/E2EQueryTest.java
+++ b/src/test/java/com/fauna/e2e/E2EQueryTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,15 @@ public class E2EQueryTest {
         var res = c.query(q);
         var exp = 42;
         assertEquals(exp, res.getData());
+    }
+
+    @Test
+    public void clientTransactionTs() {
+        FaunaClient client = Fauna.local();
+        assertTrue(client.getLastTransactionTs().isEmpty());
+        client.query(fql("42"));
+        long y2k = Instant.parse("1999-12-31T23:59:59.99Z").getEpochSecond() * 1_000_000;
+        assertTrue(client.getLastTransactionTs().orElseThrow() > y2k);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
Two key changes in here:

  1. Allow max_contention_retries to be passed in via FaunaConfig, and set the required header when querying Fauna.
  2. Update, and then pass back `last_txn_ts`.

For `max_contention_retries` I think one reason I hesitated to deal with it originally, is that I wasn't sure if it should get passed in via `QueryOptions` or `FaunaConfig`. I went with the latter because it seems more like a client-level value, but it could be changed.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
These two headers are part of the Fauna API contract, so the driver needs to set them!

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The tests `E2EQueryTest.clientTransactionTsOnSuccess|Failure` show that the returned client and Fauna API do what the code expects.=
 
### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.