### PR TITLE
[BT-5072-pagination-apis] Address BT-5072 and BT-5073

### DIFF
--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -302,17 +302,7 @@ public abstract class FaunaClient {
     }
     //endregion
 
-    /**
-     * Send a Fauna Query Language (FQL) query to Fauna and return a paginated result.
-     * @param fql               The FQL query to be executed.
-     * @param elementClass      The expected class of the query result.
-     * @return QuerySuccess     The successful query result.
-     * @throws FaunaException If the query does not succeed, an exception will be thrown.
-     */
-    public <E> PageIterator<E> paginate(Query fql, Class<E> elementClass) {
-        return new PageIterator<>(this, fql, elementClass, null);
-    }
-
+    //region Paginated API
     /**
      * Send a Fauna Query Language (FQL) query to Fauna and return a paginated result.
      * @param fql               The FQL query to be executed.
@@ -325,6 +315,41 @@ public abstract class FaunaClient {
         return new PageIterator<>(this, fql, elementClass, options);
     }
 
+    /**
+     * Send a Fauna Query Language (FQL) query to Fauna and return a paginated result.
+     * @param fql               The FQL query to be executed.
+     * @return                  The successful query result.
+     * @throws FaunaException   If the query does not succeed, an exception will be thrown.
+     */
+    public PageIterator<Object> paginate(Query fql) {
+        return new PageIterator<>(this, fql, Object.class, null);
+    }
+
+    /**
+     * Send a Fauna Query Language (FQL) query to Fauna and return a paginated result.
+     * @param fql               The FQL query to be executed.
+     * @param options           A (nullable) set of options to pass to the query.
+     * @return                  The successful query result.
+     * @throws FaunaException   If the query does not succeed, an exception will be thrown.
+     */
+    public PageIterator<Object> paginate(Query fql, QueryOptions options) {
+        return new PageIterator<>(this, fql, Object.class, options);
+    }
+
+    /**
+     * Send a Fauna Query Language (FQL) query to Fauna and return a paginated result.
+     * @param fql               The FQL query to be executed.
+     * @param elementClass      The expected class of the query result.
+     * @return QuerySuccess     The successful query result.
+     * @throws FaunaException If the query does not succeed, an exception will be thrown.
+     */
+    public <E> PageIterator<E> paginate(Query fql, Class<E> elementClass) {
+        return paginate(fql, elementClass, null);
+    }
+    //endregion
+
+
+    //region Streaming API
     /**
      * Send a request to the Fauna stream endpoint, and return a CompletableFuture that completes with the FaunaStream
      * publisher.
@@ -400,4 +425,5 @@ public abstract class FaunaClient {
         }
 
     }
+    //endregion
 }

--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -322,7 +322,7 @@ public abstract class FaunaClient {
      * @throws FaunaException   If the query does not succeed, an exception will be thrown.
      */
     public PageIterator<Object> paginate(Query fql) {
-        return new PageIterator<>(this, fql, Object.class, null);
+        return paginate(fql, Object.class, null);
     }
 
     /**
@@ -333,7 +333,7 @@ public abstract class FaunaClient {
      * @throws FaunaException   If the query does not succeed, an exception will be thrown.
      */
     public PageIterator<Object> paginate(Query fql, QueryOptions options) {
-        return new PageIterator<>(this, fql, Object.class, options);
+        return paginate(fql, Object.class, options);
     }
 
     /**

--- a/src/main/java/com/fauna/types/Page.java
+++ b/src/main/java/com/fauna/types/Page.java
@@ -2,6 +2,7 @@ package com.fauna.types;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents a page in a dataset for pagination.
@@ -21,8 +22,8 @@ public class Page<T>{
         return data;
     }
 
-    public String getAfter() {
-        return after;
+    public Optional<String> getAfter() {
+        return Optional.ofNullable(after);
     }
 
     @Override

--- a/src/test/java/com/fauna/client/PageIteratorTest.java
+++ b/src/test/java/com/fauna/client/PageIteratorTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
@@ -102,36 +101,8 @@ public class PageIteratorTest {
         when(client.asyncQuery(any(), any(ParameterizedOf.class), any())).thenReturn(failureFuture());
         PageIterator<String> pageIterator = new PageIterator<>(client, fql("hello"), String.class, null);
         // We could return the wrapped completion exception here.
-        InvalidRequestException exc = assertThrows(InvalidRequestException.class, () -> pageIterator.hasNext());
+        assertTrue(pageIterator.hasNext());
+        InvalidRequestException exc = assertThrows(InvalidRequestException.class, () -> pageIterator.next());
         assertEquals("invalid_query", exc.getResponse().getErrorCode());
-    }
-
-    @Test
-    public void test_PageIterator_from_single_Page() {
-        Page<String> page = new Page<>(List.of("hello"), null);
-        PageIterator<String> pageIterator = new PageIterator<>(client, page, String.class, null);
-        assertTrue(pageIterator.hasNext());
-        assertEquals(page, pageIterator.next());
-        assertFalse(pageIterator.hasNext());
-        assertThrows(NoSuchElementException.class, () -> pageIterator.next());
-
-    }
-
-    @Test
-    public void test_PageIterator_from_Page() throws IOException {
-        Page<String> page = new Page<>(List.of("hello"), "foo");
-        PageIterator<String> pageIterator = new PageIterator<>(client, page, String.class, null);
-
-        assertTrue(pageIterator.hasNext());
-        when(client.asyncQuery(any(), any(ParameterizedOf.class), any())).thenReturn(
-                successFuture(false, 0));
-        assertEquals(page, pageIterator.next());
-
-        assertTrue(pageIterator.hasNext());
-        assertEquals(List.of("0-a", "0-b"), pageIterator.next().getData());
-
-        assertFalse(pageIterator.hasNext());
-        assertThrows(NoSuchElementException.class, () -> pageIterator.next());
-
     }
 }

--- a/src/test/java/com/fauna/e2e/E2EPaginationTest.java
+++ b/src/test/java/com/fauna/e2e/E2EPaginationTest.java
@@ -41,7 +41,7 @@ public class E2EPaginationTest {
         assertTrue(iter.hasNext());
         Page<Product> page = iter.next();
         assertEquals(1, page.getData().size());
-        assertNull(page.getAfter());
+        assertTrue(page.getAfter().isEmpty());
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);
     }
@@ -56,7 +56,7 @@ public class E2EPaginationTest {
         // In this case the "Object" is actually a Document, so we can cast it.
         Document document = (Document) page.getData().get(0);
         assertEquals("product-1", document.get("name"));
-        assertNull(page.getAfter());
+        assertTrue(page.getAfter().isEmpty());
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);
     }
@@ -67,7 +67,7 @@ public class E2EPaginationTest {
         assertTrue(iter.hasNext());
         Page<Product> page = iter.next();
         assertEquals(8, page.getData().size());
-        assertNull(page.getAfter());
+        assertTrue(page.getAfter().isEmpty());
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);
     }
@@ -81,7 +81,7 @@ public class E2EPaginationTest {
         List<List<Product>> pages = new ArrayList<>();
 
         pages.add(latest.getData());
-        while (latest.getAfter() != null) {
+        while (latest.getAfter().isPresent()) {
             QuerySuccess<Page<Product>> paged = client.query(fql("Set.paginate(${after})", Map.of("after", latest.getAfter())), pageOf);
             latest = paged.getData();
             pages.add(latest.getData());

--- a/src/test/java/com/fauna/e2e/E2EPaginationTest.java
+++ b/src/test/java/com/fauna/e2e/E2EPaginationTest.java
@@ -6,6 +6,7 @@ import com.fauna.client.PageIterator;
 import com.fauna.e2e.beans.Product;
 import com.fauna.response.QuerySuccess;
 import com.fauna.codec.PageOf;
+import com.fauna.types.Document;
 import com.fauna.types.Page;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,21 @@ public class E2EPaginationTest {
         assertTrue(iter.hasNext());
         Page<Product> page = iter.next();
         assertEquals(1, page.getData().size());
+        assertNull(page.getAfter());
+        assertFalse(iter.hasNext());
+        assertThrows(NoSuchElementException.class, iter::next);
+    }
+
+    @Test
+    public void query_single_object_gets_wrapped_in_page() {
+        PageIterator<Object> iter = client.paginate(fql("Product.firstWhere(.name == 'product-1')"));
+        assertTrue(iter.hasNext());
+        // We didn't pass in a type, so the client returns Page<Object>
+        Page<Object> page = iter.next();
+        assertEquals(1, page.getData().size());
+        // In this case the "Object" is actually a Document, so we can cast it.
+        Document document = (Document) page.getData().get(0);
+        assertEquals("product-1", document.get("name"));
         assertNull(page.getAfter());
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);

--- a/src/test/java/com/fauna/types/PageTest.java
+++ b/src/test/java/com/fauna/types/PageTest.java
@@ -11,10 +11,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class PageTest extends TypeTestBase {
 
     @Test
-    public void page_playsNiceWithJackson() throws JsonProcessingException {
+    public void page_doesNotPlayNiceWithJackson() throws JsonProcessingException {
+        // Page no longer plays nice with Jackson, but we use our Codec/parser instead.
         var page = new Page<>(List.of(1), "next");
         var result = mapper.writeValueAsString(page);
-        assertEquals("{\"data\":[1],\"after\":\"next\"}", result);
+        assertEquals("{\"data\":[1],\"after\":{\"empty\":false,\"present\":true}}", result);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
Address two pagination items that Lucas found in the bug bash.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
 * BT-5072 keeps pagination in-line with our other APIs where QueryOptions and the element type are optional parameters.
 * BT-5073 (I think) addresses issues that developers of async apps, like restful servers might face.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added some unit and E2E tests, I think all the code I touched is "covered".

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.