### PR TITLE
[BT-5120-pagination-ergonomics] Implement queryPage and asyncQueryPage APIs..

### DIFF
--- a/src/main/java/com/fauna/client/PageIterator.java
+++ b/src/main/java/com/fauna/client/PageIterator.java
@@ -2,6 +2,7 @@ package com.fauna.client;
 
 
 import com.fauna.exception.FaunaException;
+import com.fauna.query.AfterToken;
 import com.fauna.query.QueryOptions;
 import com.fauna.query.builder.Query;
 import com.fauna.response.QuerySuccess;
@@ -21,8 +22,8 @@ import static com.fauna.query.builder.Query.fql;
  * @param <E>
  */
 public class PageIterator<E> implements Iterator<Page<E>> {
-    private static final String TOKEN_NAME = "token";
-    private static final String PAGINATE_QUERY = "Set.paginate(${" + TOKEN_NAME + "})";
+    static final String TOKEN_NAME = "token";
+    static final String PAGINATE_QUERY = "Set.paginate(${" + TOKEN_NAME + "})";
     private final FaunaClient client;
     private final QueryOptions options;
     private final PageOf<E> pageClass;
@@ -48,8 +49,11 @@ public class PageIterator<E> implements Iterator<Page<E>> {
         return this.queryFuture != null;
     }
 
-    private void doPaginatedQuery(String afterToken) {
-        this.queryFuture = client.asyncQuery(fql(PAGINATE_QUERY, Map.of(TOKEN_NAME, afterToken)), pageClass, options);
+    public static Query buildPageQuery(AfterToken afterToken) {
+        return fql(PAGINATE_QUERY, Map.of(TOKEN_NAME, afterToken.getToken()));
+    }
+    private void doPaginatedQuery(AfterToken afterToken) {
+        this.queryFuture = client.asyncQuery(PageIterator.buildPageQuery(afterToken), pageClass, options);
     }
 
     private void endPagination() {

--- a/src/main/java/com/fauna/constants/ErrorMessages.java
+++ b/src/main/java/com/fauna/constants/ErrorMessages.java
@@ -1,0 +1,8 @@
+package com.fauna.constants;
+
+public class ErrorMessages {
+    public static final String QUERY_EXECUTION = "Unable to execute query.";
+    public static final String STREAM_SUBSCRIPTION = "Unable to subscribe to stream.";
+    public static final String QUERY_PAGE = "Unable to query page.";
+
+}

--- a/src/main/java/com/fauna/exception/ErrorHandler.java
+++ b/src/main/java/com/fauna/exception/ErrorHandler.java
@@ -3,6 +3,8 @@ package com.fauna.exception;
 import com.fauna.response.QueryFailure;
 
 
+import java.util.concurrent.ExecutionException;
+
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;

--- a/src/main/java/com/fauna/query/AfterToken.java
+++ b/src/main/java/com/fauna/query/AfterToken.java
@@ -1,0 +1,19 @@
+package com.fauna.query;
+
+import java.util.Optional;
+
+public class AfterToken {
+    private final String token;
+
+    public AfterToken(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public static Optional<AfterToken> fromString(String token) {
+        return Optional.ofNullable(token != null ? new AfterToken(token) : null);
+    }
+}

--- a/src/main/java/com/fauna/types/Page.java
+++ b/src/main/java/com/fauna/types/Page.java
@@ -1,5 +1,7 @@
 package com.fauna.types;
 
+import com.fauna.query.AfterToken;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -22,8 +24,8 @@ public class Page<T>{
         return data;
     }
 
-    public Optional<String> getAfter() {
-        return Optional.ofNullable(after);
+    public Optional<AfterToken> getAfter() {
+        return AfterToken.fromString(after);
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
I added two new methods to `FaunaClient` along with some refactoring of the error handling. Note that I did _not_ add the full complement of methods with/without `QueryOptions` and `elementClass` because I think there are already a lot of methods on `FaunaClient`.

Note that changing the signature of `Page.getAfter` from `Optional<String>` to `Optional<AfterToken>` is technically a breaking change, but I think this is OK since we are still in beta.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
The feature request was driven by trying to implement a RESTful API in the sample app.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was already a nice E2E test to modify, several unit tests check that we didn't accidentally change the exception handling.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [x] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [?] My change requires a change to Fauna documentation.
* - [?] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.