### PR TITLE
[BT-5174-http-timeout] Allow user-configurable HTTP timeout for query and stream requests.

### DIFF
--- a/src/main/java/com/fauna/client/FaunaConfig.java
+++ b/src/main/java/com/fauna/client/FaunaConfig.java
@@ -8,7 +8,7 @@ import java.util.logging.Level;
 
 /**
  * FaunaConfig is a configuration class used to set up and configure a connection to Fauna.
- * It encapsulates various settings such as the endpoint URL, secret key, query timeout, and others.
+ * It encapsulates various settings such as the endpoint URL, secret key, and more.
  */
 public class FaunaConfig {
 
@@ -70,7 +70,6 @@ public class FaunaConfig {
      * Gets the buffer that will be added to the HTTP client timeout, in addition to any query timeout.
      * @return  The timeout buffer Duration.
      */
-
     public Duration getClientTimeoutBuffer() {
         return clientTimeoutBuffer;
     }
@@ -82,7 +81,6 @@ public class FaunaConfig {
     public Handler getLogHandler() {
         return logHandler;
     }
-
 
     /**
      * Creates a new builder for FaunaConfig.
@@ -172,7 +170,7 @@ public class FaunaConfig {
             return this;
         }
 
-                                  /**
+        /**
          * Builds and returns a new FaunaConfig instance.
          *
          * @return A new instance of FaunaConfig.

--- a/src/main/java/com/fauna/client/FaunaConfig.java
+++ b/src/main/java/com/fauna/client/FaunaConfig.java
@@ -1,5 +1,6 @@
 package com.fauna.client;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
@@ -19,6 +20,7 @@ public class FaunaConfig {
     private final String endpoint;
     private final String secret;
     private final int maxContentionRetries;
+    private final Duration clientTimeoutBuffer;
     private final Handler logHandler;
     public static final FaunaConfig DEFAULT = FaunaConfig.builder().build();
     public static final FaunaConfig LOCAL = FaunaConfig.builder().endpoint(
@@ -33,6 +35,7 @@ public class FaunaConfig {
         this.endpoint = builder.endpoint != null ? builder.endpoint : FaunaEndpoint.DEFAULT;
         this.secret = builder.secret != null ? builder.secret : "";
         this.maxContentionRetries = builder.maxContentionRetries;
+        this.clientTimeoutBuffer = builder.clientTimeoutBuffer;
         this.logHandler = builder.logHandler;
     }
 
@@ -64,6 +67,14 @@ public class FaunaConfig {
     }
 
     /**
+     *
+     */
+
+    public Duration getClientTimeoutBuffer() {
+        return clientTimeoutBuffer;
+    }
+
+    /**
      * Gets the log handler that the client will use.
      * @return  A log handler instance.
      */
@@ -88,6 +99,7 @@ public class FaunaConfig {
         private String endpoint = FaunaEnvironment.faunaEndpoint().orElse(FaunaEndpoint.DEFAULT);
         private String secret = FaunaEnvironment.faunaSecret().orElse("");
         private int maxContentionRetries = 3;
+        private Duration clientTimeoutBuffer = Duration.ofSeconds(5);
         private Handler logHandler = defaultLogHandler();
 
         static Level getLogLevel(String debug) {
@@ -138,6 +150,14 @@ public class FaunaConfig {
          */
         public Builder maxContentionRetries(int maxContentionRetries) {
             this.maxContentionRetries = maxContentionRetries;
+            return this;
+        }
+
+        /**
+         * Set the client timeout buffer.
+         */
+        public Builder clientTimeoutBuffer(Duration duration) {
+            this.clientTimeoutBuffer = duration;
             return this;
         }
 

--- a/src/main/java/com/fauna/client/FaunaConfig.java
+++ b/src/main/java/com/fauna/client/FaunaConfig.java
@@ -67,7 +67,8 @@ public class FaunaConfig {
     }
 
     /**
-     *
+     * Gets the buffer that will be added to the HTTP client timeout, in addition to any query timeout.
+     * @return  The timeout buffer Duration.
      */
 
     public Duration getClientTimeoutBuffer() {

--- a/src/main/java/com/fauna/client/RequestBuilder.java
+++ b/src/main/java/com/fauna/client/RequestBuilder.java
@@ -31,7 +31,6 @@ public class RequestBuilder {
     private static final String QUERY_PATH = "/query/1";
     private static final String STREAM_PATH = "/stream/1";
 
-
     private final HttpRequest.Builder baseRequestBuilder;
     private final Duration clientTimeoutBuffer;
     private final Logger logger;

--- a/src/main/java/com/fauna/stream/StreamRequest.java
+++ b/src/main/java/com/fauna/stream/StreamRequest.java
@@ -2,6 +2,7 @@ package com.fauna.stream;
 
 import com.fauna.query.StreamTokenResponse;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -10,37 +11,94 @@ import java.util.Optional;
 public class StreamRequest {
     private final String token;
     private final String cursor;
-    private final Long start_ts;
+    private final Long startTs;
+    private final Duration timeout;
 
-    public StreamRequest(String token) {
-        this.token = token;
-        this.cursor = null;
-        this.start_ts = null;
-        if (token == null || token.isEmpty()) {
-            throw new IllegalArgumentException("token cannot be null or empty");
-        }
-    }
-
-    public StreamRequest(String token, String cursor) {
+    StreamRequest(String token, String cursor, Long startTs, Duration timeout) {
         this.token = token;
         this.cursor = cursor;
-        this.start_ts = null;
+        this.startTs = startTs;
+        this.timeout = timeout;
         if (token == null || token.isEmpty()) {
             throw new IllegalArgumentException("token cannot be null or empty");
         }
-    }
-
-    public StreamRequest(String token, Long start_ts) {
-        this.token = token;
-        this.cursor = null;
-        this.start_ts = start_ts;
-        if (token == null || token.isEmpty()) {
-            throw new IllegalArgumentException("token cannot be null or empty");
+        if (cursor != null && startTs != null) {
+            throw new IllegalArgumentException("Only one of cursor, or start_ts can be set.");
         }
     }
 
     public static StreamRequest fromTokenResponse(StreamTokenResponse tokenResponse) {
-        return new StreamRequest(tokenResponse.getToken());
+        return new StreamRequest(tokenResponse.getToken(), null, null, null);
+    }
+
+    public static class Builder {
+        final String token;
+        String cursor = null;
+        Long startTs = null;
+        Duration timeout = null;
+
+        /**
+         * Return a new StreamRequest.Builder instance with the given token.
+         * @param token     A Fauna Stream token.
+         */
+        public Builder(String token) {
+            this.token = token;
+        }
+
+        /**
+         * Return the current Builder instance with the given cursor.
+         * @param cursor    A Fauna Stream cursor.
+         * @return          The current Builder instance.
+         * @throws          IllegalArgumentException If startTs has already been set.
+         */
+        public Builder cursor(String cursor) {
+            if (this.startTs != null) {
+                throw new IllegalArgumentException("only one of cursor, or startTs can be set.");
+            }
+            this.cursor = cursor;
+            return this;
+        }
+
+        /**
+         * Return the current Builder instance with the given start timestamp.
+         * @param startTs   A timestamp to start the stream at.
+         * @return          The current Builder instance.
+         * @throws          IllegalArgumentException If startTs has already been set.
+         */
+        public Builder startTs(Long startTs) {
+            if (this.cursor != null) {
+                throw new IllegalArgumentException("only one of cursor, or startTs can be set.");
+            }
+            this.startTs = startTs;
+            return this;
+        }
+
+        /**
+         * Return the current builder instance with the given timeout.
+         * This timeout is the HTTP client timeout that is passed to java.net.http.HttpRequest.Builder.
+         * By testing, it seems that the client waits for the first byte, not the last byte of the response.
+         * Therefore, it's a timeout on the stream being opened, but the stream can stay open indefinitely.
+         * @param timeout   A Duration representing the timeout.
+         * @return          The current Builder instance.
+         */
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public StreamRequest build() {
+            return new StreamRequest(token, cursor, startTs, timeout);
+        }
+
+    }
+
+    /**
+     * Create a new StreamRequest.Builder instance.
+     * @param token The Fauna Stream token to use.
+     * @return  A new StreamRequest.Builder instance.
+     */
+    public static Builder builder(String token) {
+        return new Builder(token);
     }
 
     public String getToken() {
@@ -52,6 +110,10 @@ public class StreamRequest {
     }
 
     public Optional<Long> getStartTs() {
-        return Optional.ofNullable(start_ts);
+        return Optional.ofNullable(startTs);
+    }
+
+    public Optional<Duration> getTimeout() {
+        return Optional.ofNullable(timeout);
     }
 }

--- a/src/main/java/com/fauna/stream/StreamRequest.java
+++ b/src/main/java/com/fauna/stream/StreamRequest.java
@@ -76,8 +76,11 @@ public class StreamRequest {
         /**
          * Return the current builder instance with the given timeout.
          * This timeout is the HTTP client timeout that is passed to java.net.http.HttpRequest.Builder.
-         * By testing, it seems that the client waits for the first byte, not the last byte of the response.
-         * Therefore, it's a timeout on the stream being opened, but the stream can stay open indefinitely.
+         * The Java documentation says that if "the response is not received within the specified timeout then an
+         * HttpTimeoutException is thrown". For streaming this means that the exception is thrown if the first
+         * headers/bytes are not recieved within the timeout.
+         *
+         * The default value is null if the user does not set this timeout.
          * @param timeout   A Duration representing the timeout.
          * @return          The current Builder instance.
          */
@@ -105,14 +108,29 @@ public class StreamRequest {
         return token;
     }
 
+    /**
+     * Cursor for a previous event. If provided, the stream replays any events that occurred after
+     * the cursor (exclusive).
+     * @return  The cursor, or Optional.empty() if not provided.
+     */
     public Optional<String> getCursor() {
         return Optional.ofNullable(cursor);
     }
 
+    /**
+     * Stream start time in microseconds since the Unix epoch. This is typically a previous event's txn_ts
+     * (transaction timestamp).
+     * @return The stream start time, as a Long, or Optional.empty() if not provided.
+     */
     public Optional<Long> getStartTs() {
         return Optional.ofNullable(startTs);
     }
 
+    /**
+     * Stream HTTP request timeout. This timeout is passed to java.net.http.HttpRequest.Builder. The default
+     * is null/empty.
+     * @return  The timeout Duration, or Optional.empty() if not set.
+     */
     public Optional<Duration> getTimeout() {
         return Optional.ofNullable(timeout);
     }

--- a/src/main/java/com/fauna/stream/StreamRequest.java
+++ b/src/main/java/com/fauna/stream/StreamRequest.java
@@ -104,6 +104,10 @@ public class StreamRequest {
         return new Builder(token);
     }
 
+    /**
+     * Stream token for the event stream to subscribe to.
+     * @return  A String representing the Stream token.
+     */
     public String getToken() {
         return token;
     }

--- a/src/test/java/com/fauna/client/FaunaConfigTest.java
+++ b/src/test/java/com/fauna/client/FaunaConfigTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Duration;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 
@@ -32,7 +33,9 @@ public class FaunaConfigTest {
                 .secret("foo")
                 .endpoint("endpoint")
                 .logHandler(handler)
-                .maxContentionRetries(1).build();
+                .maxContentionRetries(1)
+                .clientTimeoutBuffer(Duration.ofSeconds(1))
+                .build();
         assertEquals("endpoint", config.getEndpoint());
         assertEquals(Level.ALL, config.getLogHandler().getLevel());
         assertEquals("foo", config.getSecret());

--- a/src/test/java/com/fauna/client/RequestBuilderTest.java
+++ b/src/test/java/com/fauna/client/RequestBuilderTest.java
@@ -54,6 +54,7 @@ class RequestBuilderTest {
         assertEquals("POST", httpRequest.method());
         assertTrue(httpRequest.bodyPublisher().orElseThrow().contentLength() > 0);
         HttpHeaders headers = httpRequest.headers();
+        assertTrue(httpRequest.timeout().isEmpty());
         assertTrue(headers.firstValue(DRIVER_ENV).orElse("").contains("runtime=java"));
         assertTrue(headers.firstValue(DRIVER_ENV).orElse("").contains("driver="));
         assertNotNull(headers.firstValue(AUTHORIZATION));
@@ -76,6 +77,20 @@ class RequestBuilderTest {
         assertNotNull(headers.firstValue(QUERY_TAGS));
         assertEquals("traceParent", headers.firstValue(TRACE_PARENT).orElseThrow());
         assertEquals("1", headers.firstValue(LAST_TXN_TS).orElseThrow());
+        // Query timeout + 5 seconds (default).
+        assertEquals(Duration.ofSeconds(20), httpRequest.timeout().orElseThrow());
+    }
+
+    @Test
+    void buildRequest_withCustomTimeoutBuffer() {
+        QueryOptions defaultOpts = QueryOptions.builder().build();
+        QueryOptions timeoutOpts = QueryOptions.builder().timeout(Duration.ofSeconds(15)).build();
+
+        RequestBuilder requestBuilder = RequestBuilder.queryRequestBuilder(
+                FaunaConfig.builder().clientTimeoutBuffer(Duration.ofSeconds(1)).build(), Logger.getGlobal());
+        HttpRequest req = requestBuilder.buildRequest(fql("42"), defaultOpts, codecProvider, 1L);
+        assertEquals(Duration.ofSeconds(6), requestBuilder.buildRequest(fql("42"), defaultOpts, codecProvider, 1L).timeout().orElseThrow());
+        assertEquals(Duration.ofSeconds(16), requestBuilder.buildRequest(fql("42"), timeoutOpts, codecProvider, 1L).timeout().orElseThrow());
     }
 
     @Test

--- a/src/test/java/com/fauna/client/RequestBuilderTest.java
+++ b/src/test/java/com/fauna/client/RequestBuilderTest.java
@@ -81,7 +81,7 @@ class RequestBuilderTest {
     @Test
     void buildStreamRequestBody_shouldOnlyIncludeToken() throws IOException {
         // Given
-        StreamRequest request = new StreamRequest("tkn");
+        StreamRequest request = StreamRequest.builder("tkn").build();
         // When
         String body = requestBuilder.buildStreamRequestBody(request);
         // Then
@@ -91,7 +91,7 @@ class RequestBuilderTest {
     @Test
     void buildStreamRequestBody_shouldIncludeCursor() throws IOException {
         // Given
-        StreamRequest request = new StreamRequest("tkn", "cur");
+        StreamRequest request = StreamRequest.builder("tkn").cursor("cur").build();
         // When
         String body = requestBuilder.buildStreamRequestBody(request);
         // Then
@@ -101,7 +101,7 @@ class RequestBuilderTest {
     @Test
     void buildStreamRequestBody_shouldIncludeTimestamp() throws IOException {
         // Given
-        StreamRequest request = new StreamRequest("tkn", Long.MAX_VALUE / 2);
+        StreamRequest request = StreamRequest.builder("tkn").startTs(Long.MAX_VALUE / 2).build();
         // When
         String body = requestBuilder.buildStreamRequestBody(request);
         // Then

--- a/src/test/java/com/fauna/e2e/E2EQueryTest.java
+++ b/src/test/java/com/fauna/e2e/E2EQueryTest.java
@@ -4,7 +4,6 @@ import com.fauna.client.Fauna;
 import com.fauna.client.FaunaClient;
 import com.fauna.e2e.beans.Author;
 import com.fauna.exception.AbortException;
-import com.fauna.exception.ClientException;
 import com.fauna.exception.QueryRuntimeException;
 import com.fauna.exception.QueryTimeoutException;
 import com.fauna.query.QueryOptions;

--- a/src/test/java/com/fauna/stream/StreamRequestTest.java
+++ b/src/test/java/com/fauna/stream/StreamRequestTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StreamRequestTest {
@@ -16,7 +17,7 @@ public class StreamRequestTest {
 
     @Test
     public void testTokenOnlyRequest() {
-        StreamRequest req = new StreamRequest("abc");
+        StreamRequest req = StreamRequest.builder("abc").build();
         assertEquals("abc", req.getToken());
         assertTrue(req.getCursor().isEmpty());
         assertTrue(req.getStartTs().isEmpty());
@@ -24,7 +25,7 @@ public class StreamRequestTest {
 
     @Test
     public void testCursorRequest() {
-        StreamRequest req = new StreamRequest("abc", "def");
+        StreamRequest req = StreamRequest.builder("abc").cursor("def").build();
         assertEquals("abc", req.getToken());
         assertEquals("def", req.getCursor().get());
         assertTrue(req.getStartTs().isEmpty());
@@ -32,10 +33,16 @@ public class StreamRequestTest {
 
     @Test
     public void testTsRequest() {
-        StreamRequest req = new StreamRequest("abc", 1234L);
+        StreamRequest req = StreamRequest.builder("abc").startTs(1234L).build();
         assertEquals("abc", req.getToken());
         assertTrue(req.getCursor().isEmpty());
         assertEquals(1234L, req.getStartTs().get());
+    }
+
+    @Test
+    public void testCursorAndTsRequest() {
+        assertThrows(IllegalArgumentException.class, () -> StreamRequest.builder("tkn").startTs(10L).cursor("hello"));
+        assertThrows(IllegalArgumentException.class, () -> StreamRequest.builder("tkn").cursor("hello").startTs(10L));
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
I added support for setting the HttpClient timeout (HttpClient connect timeout, and Fauna query are already configurable).

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->

I noticed this when testing logging support on Monday. It seems minor, but could also be frustrating for customers if we don't support it.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit and E2E tests.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.