### PR TITLE
fix: handle unmaterialized sets

### DIFF
--- a/src/main/java/com/fauna/codec/UTF8FaunaParser.java
+++ b/src/main/java/com/fauna/codec/UTF8FaunaParser.java
@@ -54,11 +54,13 @@ public class UTF8FaunaParser {
     private final Stack<Object> tokenStack = new Stack<>();
     private FaunaTokenType currentFaunaTokenType = NONE;
     private FaunaTokenType bufferedFaunaTokenType;
+    private Object bufferedTokenValue;
     private String taggedTokenValue;
 
 
     private enum InternalTokenType {
-        START_ESCAPED_OBJECT
+        START_ESCAPED_OBJECT,
+        START_PAGE_UNMATERIALIZED
     }
 
     public UTF8FaunaParser(JsonParser jsonParser) {
@@ -127,6 +129,8 @@ public class UTF8FaunaParser {
             }
             return true;
         }
+
+        bufferedTokenValue = null;
 
         if (!advance()) {
             return false;
@@ -218,7 +222,20 @@ public class UTF8FaunaParser {
                     case SET_TAG:
                         advanceTrue();
                         currentFaunaTokenType = FaunaTokenType.START_PAGE;
-                        tokenStack.push(FaunaTokenType.START_PAGE);
+
+                        if (jsonParser.currentToken() == JsonToken.VALUE_STRING) {
+                            bufferedFaunaTokenType = FaunaTokenType.STRING;
+
+                            try {
+                                bufferedTokenValue = jsonParser.getValueAsString();
+                            } catch (IOException e) {
+                                throw new CodecException(e.getMessage(), e);
+                            }
+
+                            tokenStack.push(InternalTokenType.START_PAGE_UNMATERIALIZED);
+                        } else {
+                            tokenStack.push(FaunaTokenType.START_PAGE);
+                        }
                         break;
                     case REF_TAG:
                         advanceTrue();
@@ -248,6 +265,8 @@ public class UTF8FaunaParser {
         if (startToken.equals(FaunaTokenType.START_DOCUMENT)) {
             currentFaunaTokenType = END_DOCUMENT;
             advanceTrue();
+        } else if (startToken.equals(InternalTokenType.START_PAGE_UNMATERIALIZED)) {
+            currentFaunaTokenType = END_PAGE;
         } else if (startToken.equals(FaunaTokenType.START_PAGE)) {
             currentFaunaTokenType = END_PAGE;
             advanceTrue();
@@ -320,6 +339,9 @@ public class UTF8FaunaParser {
 
     public String getValueAsString() {
         try {
+            if (bufferedTokenValue != null) {
+                return bufferedTokenValue.toString();
+            }
             return jsonParser.getValueAsString();
         } catch (IOException e) {
             throw new CodecException("Error getting the current token as String", e);

--- a/src/test/java/com/fauna/codec/UTF8FaunaParserTest.java
+++ b/src/test/java/com/fauna/codec/UTF8FaunaParserTest.java
@@ -372,6 +372,26 @@ class UTF8FaunaParserTest {
         assertReader(reader, expectedTokens);
     }
 
+
+    @Test
+    public void testReadUnmaterializedSet() {
+        String s = "{\"products\":{\"@set\":\"sometoken\"},\"name\":\"foo\"}";
+        UTF8FaunaParser reader = UTF8FaunaParser.fromInputStream(new ByteArrayInputStream(s.getBytes()));
+
+        List<Map.Entry<FaunaTokenType, Object>> expectedTokens = List.of(
+                new AbstractMap.SimpleEntry<>(FaunaTokenType.START_OBJECT, null),
+                Map.entry(FaunaTokenType.FIELD_NAME, "products"),
+                new AbstractMap.SimpleEntry<>(FaunaTokenType.START_PAGE, null),
+                Map.entry(FaunaTokenType.STRING, "sometoken"),
+                new AbstractMap.SimpleEntry<>(FaunaTokenType.END_PAGE, null),
+                Map.entry(FaunaTokenType.FIELD_NAME, "name"),
+                Map.entry(FaunaTokenType.STRING, "foo"),
+                new AbstractMap.SimpleEntry<>(FaunaTokenType.END_OBJECT, null)
+        );
+
+        assertReader(reader, expectedTokens);
+    }
+
     @Test
     public void testReadRef() throws IOException {
         String s = "{\"@ref\": {\"id\": \"123\", \"coll\": {\"@mod\": \"Col\"}}}";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Add an internal token type for dealing with unmaterialized sets
* Handle start and end of unmaterialized set

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-5261

Materialized and unmaterialized sets look slightly different on the wire. In the case of materialized sets, we encounter two end object json tokens that represent the end of the set. In the unmaterialized case, we only encounter one. When the reader encounters the unmaterialized set, it will cause the token stream to be shifted by one.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added unit test

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.