### PR TITLE
chore(pipeline): Run set-self and perf tests from main

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -11,6 +11,14 @@ resources:
     source:
       url: ((slack-webhook))
 
+  - name: repo.git
+    type: git
+    icon: github
+    source:
+      uri: git@github.com:fauna/fauna-jvm.git
+      branch: main
+      private_key: ((github-ssh-key))
+
   - name: fauna-jvm-repository
     type: git
     icon: github
@@ -42,12 +50,10 @@ jobs:
   - name: set-self
     serial: true
     plan:
-      - get: fauna-jvm-repository
-        trigger: true
-      - get: fauna-jvm-repository-docs
+      - get: repo.git
         trigger: true
       - set_pipeline: self
-        file: fauna-jvm-repository/concourse/pipeline.yml
+        file: repo.git/concourse/pipeline.yml
 
   - name: perf-tests-dev
     serial: true
@@ -56,12 +62,10 @@ jobs:
       - get: dev-tests-trigger
         trigger: true
 
-      - get: fauna-jvm-repository
+      - get: repo.git
 
       - task: run-perf
-        file: fauna-jvm-repository/concourse/tasks/perf.yml
-        input_mapping:
-          repo.git: fauna-jvm-repository
+        file: repo.git/concourse/tasks/perf.yml
         params:
           FAUNA_ENDPOINT: https://db.fauna-dev.com
           FAUNA_SECRET: ((dev-driver-perf-test-key))
@@ -78,9 +82,7 @@ jobs:
     plan:
       - get: fauna-jvm-repository
         trigger: true
-        passed: [set-self]
       - get: fauna-jvm-repository-docs
-        passed: [set-self]
 
       # - in_parallel:
       #   - task: integration-tests-oracle-jdk11


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
Just a quick one: after merging my perf test PR, I noticed that the pipeline wasn't updating and it's because the whole pipeline is currently keying off of the `release` branch, so this change adds a new git resource for `main` that will trigger `set-self` and the perf tests, while the release job still runs out of the `release` branch.  There's a very slim possibility that a pipeline change in `main` that isn't cherry-picked to `release` could cause friction, but that seems highly unlikely and easy to catch in PR.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
I want my perf tests to run!  👶 

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It's Concourse, so YOLO.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.