### PR TITLE
Use stats collector

### DIFF
--- a/src/main/java/com/fauna/client/BaseFaunaClient.java
+++ b/src/main/java/com/fauna/client/BaseFaunaClient.java
@@ -25,7 +25,7 @@ public final class BaseFaunaClient extends FaunaClient {
      */
     public BaseFaunaClient(FaunaConfig faunaConfig,
                            HttpClient httpClient, RetryStrategy retryStrategy) {
-        super(faunaConfig.getSecret(), faunaConfig.getLogHandler());
+        super(faunaConfig.getSecret(), faunaConfig.getLogHandler(), faunaConfig.getStatsCollector());
         this.httpClient = httpClient;
         if (Objects.isNull(faunaConfig)) {
             throw new IllegalArgumentException("FaunaConfig cannot be null.");

--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -74,8 +74,8 @@ public abstract class FaunaClient {
         return this.logger;
     }
 
-    public Optional<StatsCollector> getStatsCollector() {
-        return Optional.ofNullable(this.statsCollector);
+    public StatsCollector getStatsCollector() {
+        return this.statsCollector;
     }
 
     public Optional<Long> getLastTransactionTs() {

--- a/src/main/java/com/fauna/client/FaunaConfig.java
+++ b/src/main/java/com/fauna/client/FaunaConfig.java
@@ -22,6 +22,7 @@ public class FaunaConfig {
     private final int maxContentionRetries;
     private final Duration clientTimeoutBuffer;
     private final Handler logHandler;
+    private final StatsCollector statsCollector;
     public static final FaunaConfig DEFAULT = FaunaConfig.builder().build();
     public static final FaunaConfig LOCAL = FaunaConfig.builder().endpoint(
             FaunaEndpoint.LOCAL).secret("secret").build();
@@ -37,6 +38,7 @@ public class FaunaConfig {
         this.maxContentionRetries = builder.maxContentionRetries;
         this.clientTimeoutBuffer = builder.clientTimeoutBuffer;
         this.logHandler = builder.logHandler;
+        this.statsCollector = builder.statsCollector;
     }
 
     /**
@@ -83,6 +85,14 @@ public class FaunaConfig {
     }
 
     /**
+     * Gets the stats collector for the client.
+     * @return A log handler instance.
+     */
+    public StatsCollector getStatsCollector() {
+        return statsCollector;
+    }
+
+    /**
      * Creates a new builder for FaunaConfig.
      *
      * @return A new instance of Builder.
@@ -100,6 +110,7 @@ public class FaunaConfig {
         private int maxContentionRetries = 3;
         private Duration clientTimeoutBuffer = Duration.ofSeconds(5);
         private Handler logHandler = defaultLogHandler();
+        private StatsCollector statsCollector;
 
         static Level getLogLevel(String debug) {
             if (debug == null || debug.isBlank()) {
@@ -167,6 +178,25 @@ public class FaunaConfig {
          */
         public Builder logHandler(Handler handler) {
             this.logHandler = handler;
+            return this;
+        }
+
+        /**
+         * Set a StatsCollector.
+         * @param statsCollector    A stats collector instance.
+         * @return                  The current Builder instance.
+         */
+        public Builder statsCollector(StatsCollector statsCollector) {
+            this.statsCollector = statsCollector;
+            return this;
+        }
+
+        /**
+         * Set a default StatsCollector.
+         * @return  The current Builder instance.
+         */
+        public Builder defaultStatsCollector() {
+            this.statsCollector = new StatsCollectorImpl();
             return this;
         }
 

--- a/src/main/java/com/fauna/client/FaunaConfig.java
+++ b/src/main/java/com/fauna/client/FaunaConfig.java
@@ -86,7 +86,7 @@ public class FaunaConfig {
 
     /**
      * Gets the stats collector for the client.
-     * @return A log handler instance.
+     * @return A StatsCollector instance.
      */
     public StatsCollector getStatsCollector() {
         return statsCollector;
@@ -110,7 +110,7 @@ public class FaunaConfig {
         private int maxContentionRetries = 3;
         private Duration clientTimeoutBuffer = Duration.ofSeconds(5);
         private Handler logHandler = defaultLogHandler();
-        private StatsCollector statsCollector;
+        private StatsCollector statsCollector = new StatsCollectorImpl();
 
         static Level getLogLevel(String debug) {
             if (debug == null || debug.isBlank()) {
@@ -188,15 +188,6 @@ public class FaunaConfig {
          */
         public Builder statsCollector(StatsCollector statsCollector) {
             this.statsCollector = statsCollector;
-            return this;
-        }
-
-        /**
-         * Set a default StatsCollector.
-         * @return  The current Builder instance.
-         */
-        public Builder defaultStatsCollector() {
-            this.statsCollector = new StatsCollectorImpl();
             return this;
         }
 

--- a/src/main/java/com/fauna/client/FaunaStream.java
+++ b/src/main/java/com/fauna/client/FaunaStream.java
@@ -64,9 +64,7 @@ public class FaunaStream<E> extends SubmissionPublisher<StreamEvent<E>> implemen
                     JsonParser parser = JSON_FACTORY.createParser(buffer);
                     StreamEvent<E> event = StreamEvent.parse(parser, dataCodec);
 
-                    if (statsCollector != null) {
-                        statsCollector.add(event.getStats());
-                    }
+                    statsCollector.add(event.getStats());
 
                     if (event.getType() == StreamEvent.EventType.ERROR) {
                         ErrorInfo error = event.getError();

--- a/src/main/java/com/fauna/client/ScopedFaunaClient.java
+++ b/src/main/java/com/fauna/client/ScopedFaunaClient.java
@@ -9,7 +9,7 @@ public class ScopedFaunaClient extends FaunaClient {
 
 
     public ScopedFaunaClient(FaunaClient client, FaunaScope scope) {
-        super(client.getFaunaSecret(), client.getLogger(), client.getStatsCollector().orElse(null));
+        super(client.getFaunaSecret(), client.getLogger(), client.getStatsCollector().clone());
         this.client = client;
         this.requestBuilder = client.getRequestBuilder().scopedRequestBuilder(scope.getToken(client.getFaunaSecret()));
         this.streamRequestBuilder = client.getStreamRequestBuilder().scopedRequestBuilder(scope.getToken(client.getFaunaSecret()));

--- a/src/main/java/com/fauna/client/ScopedFaunaClient.java
+++ b/src/main/java/com/fauna/client/ScopedFaunaClient.java
@@ -9,7 +9,7 @@ public class ScopedFaunaClient extends FaunaClient {
 
 
     public ScopedFaunaClient(FaunaClient client, FaunaScope scope) {
-        super(client.getFaunaSecret(), client.getLogger());
+        super(client.getFaunaSecret(), client.getLogger(), client.getStatsCollector().orElse(null));
         this.client = client;
         this.requestBuilder = client.getRequestBuilder().scopedRequestBuilder(scope.getToken(client.getFaunaSecret()));
         this.streamRequestBuilder = client.getStreamRequestBuilder().scopedRequestBuilder(scope.getToken(client.getFaunaSecret()));

--- a/src/main/java/com/fauna/client/StatsCollector.java
+++ b/src/main/java/com/fauna/client/StatsCollector.java
@@ -21,4 +21,10 @@ public interface StatsCollector {
      * @return Stats object
      */
     QueryStatsSummary readAndReset();
+
+    /**
+     * Clone the stats collector instance.
+     * @return A clone of the stats collector instance.
+     */
+    StatsCollector clone();
 }

--- a/src/main/java/com/fauna/client/StatsCollectorImpl.java
+++ b/src/main/java/com/fauna/client/StatsCollectorImpl.java
@@ -89,5 +89,10 @@ public class StatsCollectorImpl implements StatsCollector {
                 rateLimitedWriteQueryCount.getAndSet(0)
         );
     }
+
+    @Override
+    public StatsCollector clone() {
+        return new StatsCollectorImpl();
+    }
 }
 

--- a/src/main/java/com/fauna/response/QueryResponse.java
+++ b/src/main/java/com/fauna/response/QueryResponse.java
@@ -149,7 +149,7 @@ public abstract class QueryResponse {
                 builder = handleField(builder, parser);
             }
 
-            if (statsCollector != null && builder.stats != null) {
+            if (builder.stats != null) {
                 statsCollector.add(builder.stats);
             }
 

--- a/src/main/java/com/fauna/response/QueryResponse.java
+++ b/src/main/java/com/fauna/response/QueryResponse.java
@@ -3,6 +3,7 @@ package com.fauna.response;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fauna.client.StatsCollector;
 import com.fauna.codec.Codec;
 import com.fauna.codec.UTF8FaunaParser;
 import com.fauna.exception.ClientResponseException;
@@ -135,7 +136,7 @@ public abstract class QueryResponse {
         }
     }
 
-    public static <T>  QuerySuccess<T> parseResponse(HttpResponse<InputStream> response, Codec<T> codec) throws FaunaException {
+    public static <T>  QuerySuccess<T> parseResponse(HttpResponse<InputStream> response, Codec<T> codec, StatsCollector statsCollector) throws FaunaException {
         try {
             JsonParser parser = JSON_FACTORY.createParser(response.body());
 
@@ -147,6 +148,11 @@ public abstract class QueryResponse {
             while (parser.nextToken() == JsonToken.FIELD_NAME) {
                 builder = handleField(builder, parser);
             }
+
+            if (statsCollector != null && builder.stats != null) {
+                statsCollector.add(builder.stats);
+            }
+
             int httpStatus = response.statusCode();
             if (httpStatus >= 400) {
                 QueryFailure failure = new QueryFailure(httpStatus, builder);

--- a/src/test/java/com/fauna/client/FaunaClientTest.java
+++ b/src/test/java/com/fauna/client/FaunaClientTest.java
@@ -39,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static com.fauna.query.builder.Query.fql;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -81,7 +82,7 @@ class FaunaClientTest {
     void defaultClient() {
         FaunaClient client = Fauna.client();
         assertTrue(client.getHttpClient().connectTimeout().isEmpty());
-        assertTrue(client.getStatsCollector().isEmpty());
+        assertNotNull(client.getStatsCollector());
         assertEquals(URI.create("https://db.fauna.com/query/1"),
                 client.getRequestBuilder().buildRequest(
                         fql("hello"), QueryOptions.builder().build(), DefaultCodecProvider.SINGLETON, 1L).uri());
@@ -104,11 +105,10 @@ class FaunaClientTest {
     void customConfigConstructor() {
         FaunaConfig cfg = FaunaConfig.builder()
                 .secret("foo")
-                .defaultStatsCollector()
                 .build();
         FaunaClient client = Fauna.client(cfg);
         assertTrue(client.toString().startsWith("com.fauna.client.BaseFaunaClient"));
-        assertTrue(client.getStatsCollector().isPresent());
+        assertNotNull(client.getStatsCollector());
     }
 
     @Test

--- a/src/test/java/com/fauna/client/FaunaClientTest.java
+++ b/src/test/java/com/fauna/client/FaunaClientTest.java
@@ -81,16 +81,10 @@ class FaunaClientTest {
     void defaultClient() {
         FaunaClient client = Fauna.client();
         assertTrue(client.getHttpClient().connectTimeout().isEmpty());
+        assertTrue(client.getStatsCollector().isEmpty());
         assertEquals(URI.create("https://db.fauna.com/query/1"),
                 client.getRequestBuilder().buildRequest(
                         fql("hello"), QueryOptions.builder().build(), DefaultCodecProvider.SINGLETON, 1L).uri());
-    }
-
-    @Test
-    void defaultConfigBuilder() {
-        FaunaConfig config = FaunaConfig.builder().build();
-        assertEquals("https://db.fauna.com", config.getEndpoint());
-        assertEquals("", config.getSecret());
     }
 
     @Test
@@ -108,8 +102,13 @@ class FaunaClientTest {
 
     @Test
     void customConfigConstructor() {
-        FaunaClient client = Fauna.client(FaunaConfig.builder().secret("foo").build());
+        FaunaConfig cfg = FaunaConfig.builder()
+                .secret("foo")
+                .defaultStatsCollector()
+                .build();
+        FaunaClient client = Fauna.client(cfg);
         assertTrue(client.toString().startsWith("com.fauna.client.BaseFaunaClient"));
+        assertTrue(client.getStatsCollector().isPresent());
     }
 
     @Test

--- a/src/test/java/com/fauna/client/FaunaConfigTest.java
+++ b/src/test/java/com/fauna/client/FaunaConfigTest.java
@@ -23,7 +23,7 @@ public class FaunaConfigTest {
         assertEquals(Level.WARNING, config.getLogHandler().getLevel());
         assertEquals("", config.getSecret());
         assertEquals(3, config.getMaxContentionRetries());
-        assertNull(config.getStatsCollector());
+        assertNotNull(config.getStatsCollector());
     }
 
     @Test
@@ -38,7 +38,6 @@ public class FaunaConfigTest {
                 .logHandler(handler)
                 .maxContentionRetries(1)
                 .clientTimeoutBuffer(Duration.ofSeconds(1))
-                .defaultStatsCollector()
                 .build();
         assertEquals("endpoint", config.getEndpoint());
         assertEquals(Level.ALL, config.getLogHandler().getLevel());

--- a/src/test/java/com/fauna/client/FaunaConfigTest.java
+++ b/src/test/java/com/fauna/client/FaunaConfigTest.java
@@ -8,6 +8,8 @@ import java.time.Duration;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FaunaConfigTest {
@@ -21,6 +23,7 @@ public class FaunaConfigTest {
         assertEquals(Level.WARNING, config.getLogHandler().getLevel());
         assertEquals("", config.getSecret());
         assertEquals(3, config.getMaxContentionRetries());
+        assertNull(config.getStatsCollector());
     }
 
     @Test
@@ -35,11 +38,13 @@ public class FaunaConfigTest {
                 .logHandler(handler)
                 .maxContentionRetries(1)
                 .clientTimeoutBuffer(Duration.ofSeconds(1))
+                .defaultStatsCollector()
                 .build();
         assertEquals("endpoint", config.getEndpoint());
         assertEquals(Level.ALL, config.getLogHandler().getLevel());
         assertEquals("foo", config.getSecret());
         assertEquals(1, config.getMaxContentionRetries());
+        assertNotNull(config.getStatsCollector());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/fauna/e2e/E2EPaginationTest.java
+++ b/src/test/java/com/fauna/e2e/E2EPaginationTest.java
@@ -2,6 +2,7 @@ package com.fauna.e2e;
 
 import com.fauna.client.Fauna;
 import com.fauna.client.FaunaClient;
+import com.fauna.client.FaunaConfig;
 import com.fauna.client.PageIterator;
 import com.fauna.e2e.beans.Product;
 import com.fauna.response.QuerySuccess;
@@ -110,5 +111,39 @@ public class E2EPaginationTest {
             products.add(p);
         }
         assertEquals(50, products.size());
+    }
+
+    @Test
+    public void query_statsAreTrackedForExplicitPagination() {
+        var cfg = FaunaConfig.builder()
+                .secret("secret")
+                .endpoint("http://localhost:8443")
+                .defaultStatsCollector()
+                .build();
+        var client = Fauna.client(cfg);
+        PageIterator<Product> iter = client.paginate(fql("Product.all()"), Product.class);
+        iter.forEachRemaining(page -> {});
+
+        var stats = client.getStatsCollector().get().read();
+        assertEquals(82, stats.getReadOps());
+        assertEquals(4, stats.getComputeOps());
+    }
+
+    @Test
+    public void query_statsAreTrackedForFlattenedPagination() {
+        var cfg = FaunaConfig.builder()
+                .secret("secret")
+                .endpoint("http://localhost:8443")
+                .defaultStatsCollector()
+                .build();
+        var client = Fauna.client(cfg);
+        PageIterator<Product> iter = client.paginate(fql("Product.all()"), Product.class);
+        Iterator<Product> productIter = iter.flatten();
+        for (Product p : (Iterable<Product>) () -> productIter) {
+        }
+
+        var stats = client.getStatsCollector().get().read();
+        assertEquals(82, stats.getReadOps());
+        assertEquals(4, stats.getComputeOps());
     }
 }

--- a/src/test/java/com/fauna/e2e/E2EPaginationTest.java
+++ b/src/test/java/com/fauna/e2e/E2EPaginationTest.java
@@ -118,13 +118,12 @@ public class E2EPaginationTest {
         var cfg = FaunaConfig.builder()
                 .secret("secret")
                 .endpoint("http://localhost:8443")
-                .defaultStatsCollector()
                 .build();
         var client = Fauna.client(cfg);
         PageIterator<Product> iter = client.paginate(fql("Product.all()"), Product.class);
         iter.forEachRemaining(page -> {});
 
-        var stats = client.getStatsCollector().get().read();
+        var stats = client.getStatsCollector().read();
         assertEquals(82, stats.getReadOps());
         assertEquals(4, stats.getComputeOps());
     }
@@ -134,7 +133,6 @@ public class E2EPaginationTest {
         var cfg = FaunaConfig.builder()
                 .secret("secret")
                 .endpoint("http://localhost:8443")
-                .defaultStatsCollector()
                 .build();
         var client = Fauna.client(cfg);
         PageIterator<Product> iter = client.paginate(fql("Product.all()"), Product.class);
@@ -142,7 +140,7 @@ public class E2EPaginationTest {
         for (Product p : (Iterable<Product>) () -> productIter) {
         }
 
-        var stats = client.getStatsCollector().get().read();
+        var stats = client.getStatsCollector().read();
         assertEquals(82, stats.getReadOps());
         assertEquals(4, stats.getComputeOps());
     }

--- a/src/test/java/com/fauna/e2e/E2EQueryTest.java
+++ b/src/test/java/com/fauna/e2e/E2EQueryTest.java
@@ -284,14 +284,13 @@ public class E2EQueryTest {
         var cfg = FaunaConfig.builder()
                 .secret("secret")
                 .endpoint("http://localhost:8443")
-                .defaultStatsCollector()
                 .build();
         var client = Fauna.client(cfg);
 
         var q = fql("Author.all().toArray()");
 
         client.query(q, listOf(Author.class));
-        var stats = client.getStatsCollector().get().read();
+        var stats = client.getStatsCollector().read();
         assertEquals(10, stats.getReadOps());
         assertEquals(1, stats.getComputeOps());
     }
@@ -301,13 +300,12 @@ public class E2EQueryTest {
         var cfg = FaunaConfig.builder()
                 .secret("secret")
                 .endpoint("http://localhost:8443")
-                .defaultStatsCollector()
                 .build();
         var client = Fauna.client(cfg);
 
         var q = fql("Author.all().toArray()\nabort(null)");
         assertThrows(AbortException.class, () -> client.query(q));
-        var stats = client.getStatsCollector().get().read();
+        var stats = client.getStatsCollector().read();
         assertEquals(8, stats.getReadOps());
         assertEquals(1, stats.getComputeOps());
     }

--- a/src/test/java/com/fauna/e2e/E2EStreamingTest.java
+++ b/src/test/java/com/fauna/e2e/E2EStreamingTest.java
@@ -117,12 +117,11 @@ public class E2EStreamingTest {
         var cfg = FaunaConfig.builder()
                 .secret("secret")
                 .endpoint("http://localhost:8443")
-                .defaultStatsCollector()
                 .build();
         var streamClient = Fauna.client(cfg);
 
-        FaunaStream stream = streamClient.stream(fql("Product.all().toStream()"), Product.class);
-        var stats = streamClient.getStatsCollector().get().readAndReset();
+        FaunaStream<Product> stream = streamClient.stream(fql("Product.all().toStream()"), Product.class);
+        var stats = streamClient.getStatsCollector().readAndReset();
         assertEquals(1, stats.getComputeOps());
 
         InventorySubscriber inventory = new InventorySubscriber();
@@ -153,7 +152,7 @@ public class E2EStreamingTest {
         stream.close();
         assertTrue(stream.isClosed());
 
-        stats = streamClient.getStatsCollector().get().read();
+        stats = streamClient.getStatsCollector().read();
         assertEquals(11, stats.getReadOps());
         assertEquals(events, stats.getComputeOps());
     }

--- a/src/test/java/com/fauna/exception/ConstraintFailureTest.java
+++ b/src/test/java/com/fauna/exception/ConstraintFailureTest.java
@@ -97,7 +97,7 @@ public class ConstraintFailureTest {
         HttpResponse<InputStream> resp = mock(HttpResponse.class);
         when(resp.body()).thenReturn(new ByteArrayInputStream(body.getBytes()));
         when(resp.statusCode()).thenReturn(400);
-        ConstraintFailureException exc = assertThrows(ConstraintFailureException.class,() -> QueryResponse.parseResponse(resp, null));
+        ConstraintFailureException exc = assertThrows(ConstraintFailureException.class,() -> QueryResponse.parseResponse(resp, null, null));
         assertEquals(Optional.of(List.of("name")), exc.getConstraintFailures()[0].getPathStrings());
     }
 
@@ -109,7 +109,7 @@ public class ConstraintFailureTest {
         HttpResponse<InputStream> resp = mock(HttpResponse.class);
         when(resp.body()).thenReturn(new ByteArrayInputStream(body.getBytes()));
         when(resp.statusCode()).thenReturn(400);
-        ConstraintFailureException exc = assertThrows(ConstraintFailureException.class,() -> QueryResponse.parseResponse(resp, null));
+        ConstraintFailureException exc = assertThrows(ConstraintFailureException.class,() -> QueryResponse.parseResponse(resp, null, null));
         assertEquals(Optional.of(List.of("name", "name2.1.2.name3")), exc.getConstraintFailures()[0].getPathStrings());
     }
 

--- a/src/test/java/com/fauna/exception/TestErrorHandler.java
+++ b/src/test/java/com/fauna/exception/TestErrorHandler.java
@@ -65,7 +65,7 @@ public class TestErrorHandler {
         HttpResponse<InputStream> resp = mock(HttpResponse.class);
         when(resp.body()).thenReturn(new ByteArrayInputStream(root.toString().getBytes()));
         when(resp.statusCode()).thenReturn(args.httpStatus);
-        assertThrows(args.exception, () -> parseResponse(resp, null));
+        assertThrows(args.exception, () -> parseResponse(resp, null, null));
     }
 
 }

--- a/src/test/java/com/fauna/response/QueryResponseTest.java
+++ b/src/test/java/com/fauna/response/QueryResponseTest.java
@@ -55,7 +55,7 @@ class QueryResponseTest {
         HttpResponse resp = mockResponse(body);
         when(resp.statusCode()).thenReturn(200);
 
-        QuerySuccess<ClassWithAttributes> success = QueryResponse.parseResponse(resp, codec);
+        QuerySuccess<ClassWithAttributes> success = QueryResponse.parseResponse(resp, codec, null);
 
         assertEquals(baz.getFirstName(), success.getData().getFirstName());
         assertEquals("PersonWithAttributes", success.getStaticType().get());
@@ -68,14 +68,14 @@ class QueryResponseTest {
         HttpResponse resp = mockResponse("{\"not valid json\"");
         when(resp.statusCode()).thenReturn(400);
 
-        ClientResponseException exc = assertThrows(ClientResponseException.class, () -> QueryResponse.parseResponse(resp, codecProvider.get(Object.class)));
+        ClientResponseException exc = assertThrows(ClientResponseException.class, () -> QueryResponse.parseResponse(resp, codecProvider.get(Object.class), null));
         assertEquals("ClientResponseException HTTP 400: Failed to handle error response.", exc.getMessage());
     }
 
     @Test
     public void handleResponseWithEmptyFieldsDoesNotThrow() {
         HttpResponse resp = mockResponse("{}");
-        QuerySuccess<Object> response = QueryResponse.parseResponse(resp,  codecProvider.get(Object.class));
+        QuerySuccess<Object> response = QueryResponse.parseResponse(resp,  codecProvider.get(Object.class), null);
         assertEquals(QuerySuccess.class, response.getClass());
         assertNull(response.getSchemaVersion());
         assertNull(response.getSummary());

--- a/src/test/java/com/fauna/response/QueryResponseTest.java
+++ b/src/test/java/com/fauna/response/QueryResponseTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fauna.beans.ClassWithAttributes;
+import com.fauna.client.StatsCollectorImpl;
 import com.fauna.codec.Codec;
 import com.fauna.codec.CodecProvider;
 import com.fauna.codec.CodecRegistry;
@@ -55,7 +56,7 @@ class QueryResponseTest {
         HttpResponse resp = mockResponse(body);
         when(resp.statusCode()).thenReturn(200);
 
-        QuerySuccess<ClassWithAttributes> success = QueryResponse.parseResponse(resp, codec, null);
+        QuerySuccess<ClassWithAttributes> success = QueryResponse.parseResponse(resp, codec, new StatsCollectorImpl());
 
         assertEquals(baz.getFirstName(), success.getData().getFirstName());
         assertEquals("PersonWithAttributes", success.getStaticType().get());
@@ -68,14 +69,14 @@ class QueryResponseTest {
         HttpResponse resp = mockResponse("{\"not valid json\"");
         when(resp.statusCode()).thenReturn(400);
 
-        ClientResponseException exc = assertThrows(ClientResponseException.class, () -> QueryResponse.parseResponse(resp, codecProvider.get(Object.class), null));
+        ClientResponseException exc = assertThrows(ClientResponseException.class, () -> QueryResponse.parseResponse(resp, codecProvider.get(Object.class), new StatsCollectorImpl()));
         assertEquals("ClientResponseException HTTP 400: Failed to handle error response.", exc.getMessage());
     }
 
     @Test
     public void handleResponseWithEmptyFieldsDoesNotThrow() {
         HttpResponse resp = mockResponse("{}");
-        QuerySuccess<Object> response = QueryResponse.parseResponse(resp,  codecProvider.get(Object.class), null);
+        QuerySuccess<Object> response = QueryResponse.parseResponse(resp,  codecProvider.get(Object.class), new StatsCollectorImpl());
         assertEquals(QuerySuccess.class, response.getClass());
         assertNull(response.getSchemaVersion());
         assertNull(response.getSummary());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Use the stats collector from https://github.com/fauna/fauna-jvm/pull/159
  * Collect stats on queries
  * Collect stats on pagination (this happens through queries)
  * Collect stats on stream events

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-4971

* Some users want to track query stats (like read/write/compute ops) at the top level
* In the case of pagination, there's no way to track stats on the individual requests

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Integration tests for streams, pagination, and queries

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.