### PR TITLE
Add a build task to bundle the jar with deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,5 +101,13 @@ task writeProps(type: WriteProperties) {
     property('name', project.name)
     property('group', project.group)
 }
+
+tasks.register('packageJar', Zip) {
+    into('lib') {
+        from(tasks.jar)
+        from(configurations.runtimeClasspath)
+    }
+}
+
 processResources.dependsOn(writeProps)
 sourcesJar.dependsOn(writeProps)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Add a build step that will bundle the jar with all dependencies. It will zip to `build/distributions/fauna-jvm-<version>.zip`

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
BT-4262

* For platform testing need to build the jar and bundle all of its dependencies to deploy to a cloud provider, such as AWS Lambda, for integration testing.


### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* I ran the build task locally and copied its output into our test app, then deployed it to AWS Lambda to verify it works. It does.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.