### PR TITLE
[BT-5271-streams-api] Align the Streams API with Event Feeds terminology.

### DIFF
--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -8,17 +8,13 @@ import com.fauna.event.FaunaStream;
 import com.fauna.event.FeedIterator;
 import com.fauna.event.StreamOptions;
 import com.fauna.exception.ClientException;
-import com.fauna.exception.ErrorHandler;
 import com.fauna.exception.FaunaException;
-import com.fauna.exception.ProtocolException;
 import com.fauna.exception.ServiceException;
 import com.fauna.event.EventSource;
 import com.fauna.event.FeedOptions;
 import com.fauna.event.FeedPage;
 import com.fauna.query.AfterToken;
 import com.fauna.query.QueryOptions;
-import com.fauna.response.QueryFailure;
-import com.fauna.event.StreamRequest;
 import com.fauna.event.EventSourceResponse;
 import com.fauna.query.builder.Query;
 import com.fauna.response.QueryResponse;
@@ -144,15 +140,6 @@ public abstract class FaunaClient {
         return () -> client.sendAsync(request, HttpResponse.BodyHandlers.ofInputStream()).thenApply(
                 response -> {
                     logResponse(response);
-                    if (response.statusCode() >= 400) {
-                        // There are possibly some different error cases to handle for feeds. This seems like
-                        // a comprehensive solution for now. In the future we could rename QueryFailure et. al. to
-                        // something like FaunaFailure, or implement "FeedFailure".
-                        QueryFailure failure = new QueryFailure(response.statusCode(), QueryResponse.builder(codec));
-                        ErrorHandler.handleQueryFailure(response.statusCode(), failure);
-                        // Fall back on ProtocolException.
-                        throw new ProtocolException(response.statusCode(), failure);
-                    }
                     return FeedPage.parseResponse(response, codec, statsCollector);
                 }).whenComplete(this::completeFeedRequest);
     }

--- a/src/main/java/com/fauna/client/FaunaClient.java
+++ b/src/main/java/com/fauna/client/FaunaClient.java
@@ -153,7 +153,7 @@ public abstract class FaunaClient {
                         // Fall back on ProtocolException.
                         throw new ProtocolException(response.statusCode(), failure);
                     }
-                    return FeedPage.parseResponse(response, codec);
+                    return FeedPage.parseResponse(response, codec, statsCollector);
                 }).whenComplete(this::completeFeedRequest);
     }
 

--- a/src/main/java/com/fauna/client/PageIterator.java
+++ b/src/main/java/com/fauna/client/PageIterator.java
@@ -44,6 +44,13 @@ public class PageIterator<E> implements Iterator<Page<E>> {
         this.queryFuture = client.asyncQuery(fql, this.pageClass, options);
     }
 
+    public PageIterator(FaunaClient client, Page<E> firstPage, Class<E> resultClass, QueryOptions options) {
+        this.client = client;
+        this.pageClass = new PageOf<>(resultClass);
+        this.options = options;
+        firstPage.getAfter().ifPresentOrElse(this::doPaginatedQuery, this::endPagination);
+    }
+
     @Override
     public boolean hasNext() {
         return this.queryFuture != null;

--- a/src/main/java/com/fauna/event/StreamOptions.java
+++ b/src/main/java/com/fauna/event/StreamOptions.java
@@ -2,18 +2,29 @@ package com.fauna.event;
 
 import com.fauna.client.RetryStrategy;
 
+import java.time.Duration;
 import java.util.Optional;
 
 public class StreamOptions {
 
+    private final String cursor;
     private final RetryStrategy retryStrategy;
     private final Long startTimestamp;
     private final Boolean statusEvents;
+    private final Duration timeout;
+
+    public static final StreamOptions DEFAULT = StreamOptions.builder().build();
 
     public StreamOptions(Builder builder) {
+        this.cursor = builder.cursor;
         this.retryStrategy = builder.retryStrategy;
         this.startTimestamp = builder.startTimestamp;
         this.statusEvents = builder.statusEvents;
+        this.timeout = builder.timeout;
+    }
+
+    public Optional<String> getCursor() {
+        return Optional.ofNullable(cursor);
     }
 
     public Optional<RetryStrategy> getRetryStrategy() {
@@ -29,24 +40,40 @@ public class StreamOptions {
         return Optional.ofNullable(statusEvents);
     }
 
+    public Optional<Duration> getTimeout() {
+        return Optional.ofNullable(timeout);
+    }
+
 
     public static class Builder {
+        public String cursor = null;
         public RetryStrategy retryStrategy = null;
         public Long startTimestamp = null;
         public Boolean statusEvents = null;
+        public Duration timeout = null;
 
-        public Builder withRetryStrategy(RetryStrategy retryStrategy) {
+        public Builder cursor(String cursor) {
+            this.cursor = cursor;
+            return this;
+        }
+
+        public Builder retryStrategy(RetryStrategy retryStrategy) {
             this.retryStrategy = retryStrategy;
             return this;
         }
 
-        public Builder withStartTimestamp(long startTimestamp) {
+        public Builder startTimestamp(long startTimestamp) {
             this.startTimestamp = startTimestamp;
             return this;
         }
 
-        public Builder withStatusEvents(Boolean statusEvents) {
+        public Builder statusEvents(Boolean statusEvents) {
             this.statusEvents = statusEvents;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
             return this;
         }
 

--- a/src/main/java/com/fauna/event/StreamRequest.java
+++ b/src/main/java/com/fauna/event/StreamRequest.java
@@ -1,5 +1,13 @@
 package com.fauna.event;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fauna.client.RequestBuilder;
+import jdk.jfr.Event;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -7,133 +15,37 @@ import java.util.Optional;
  * This class defines the request body expected by the fauna /stream endpoint.
  */
 public class StreamRequest {
-    private final String token;
-    private final String cursor;
-    private final Long startTs;
-    private final Duration timeout;
+    private final EventSource source;
+    private final StreamOptions options;
 
-    StreamRequest(String token, String cursor, Long startTs, Duration timeout) {
-        this.token = token;
-        this.cursor = cursor;
-        this.startTs = startTs;
-        this.timeout = timeout;
-        if (token == null || token.isEmpty()) {
-            throw new IllegalArgumentException("token cannot be null or empty");
+    public StreamRequest(EventSource eventSource, StreamOptions streamOptions) {
+        this.source = eventSource;
+        this.options = streamOptions;
+        if (source == null) {
+            throw new IllegalArgumentException("Event source cannot be null.");
         }
-        if (cursor != null && startTs != null) {
-            throw new IllegalArgumentException("Only one of cursor, or start_ts can be set.");
+        if (options == null) {
+            throw new IllegalArgumentException("Stream options cannot be null.");
         }
     }
 
-    public static StreamRequest fromTokenResponse(EventSourceResponse tokenResponse) {
-        return new StreamRequest(tokenResponse.getToken(), null, null, null);
-    }
-
-    public static class Builder {
-        final String token;
-        String cursor = null;
-        Long startTs = null;
-        Duration timeout = null;
-
-        /**
-         * Return a new StreamRequest.Builder instance with the given token.
-         * @param token     A Fauna Stream token.
-         */
-        public Builder(String token) {
-            this.token = token;
+    public String serialize() throws IOException {
+        // Use JsonGenerator directly rather than UTF8FaunaGenerator because this is not FQL. For example,
+        // start_ts is a JSON numeric/integer, not a tagged '@long'.
+        ByteArrayOutputStream requestBytes = new ByteArrayOutputStream();
+        JsonGenerator gen = new JsonFactory().createGenerator(requestBytes);
+        gen.writeStartObject();
+        gen.writeStringField(RequestBuilder.FieldNames.TOKEN, source.getToken());
+        // Only one of cursor / start_ts can be present, prefer cursor.
+        // Cannot use ifPresent(val -> ...) because gen.write methods can throw an IOException.
+        if (options.getCursor().isPresent()) {
+            gen.writeStringField(RequestBuilder.FieldNames.CURSOR, options.getCursor().get());
+        } else if (options.getStartTimestamp().isPresent()) {
+            gen.writeNumberField(RequestBuilder.FieldNames.START_TS, options.getStartTimestamp().get());
         }
-
-        /**
-         * Return the current Builder instance with the given cursor.
-         * @param cursor    A Fauna Stream cursor.
-         * @return          The current Builder instance.
-         * @throws          IllegalArgumentException If startTs has already been set.
-         */
-        public Builder cursor(String cursor) {
-            if (this.startTs != null) {
-                throw new IllegalArgumentException("only one of cursor, or startTs can be set.");
-            }
-            this.cursor = cursor;
-            return this;
-        }
-
-        /**
-         * Return the current Builder instance with the given start timestamp.
-         * @param startTs   A timestamp to start the stream at.
-         * @return          The current Builder instance.
-         * @throws          IllegalArgumentException If startTs has already been set.
-         */
-        public Builder startTs(Long startTs) {
-            if (this.cursor != null) {
-                throw new IllegalArgumentException("only one of cursor, or startTs can be set.");
-            }
-            this.startTs = startTs;
-            return this;
-        }
-
-        /**
-         * Return the current builder instance with the given timeout.
-         * This timeout is the HTTP client timeout that is passed to java.net.http.HttpRequest.Builder.
-         * The Java documentation says that if "the response is not received within the specified timeout then an
-         * HttpTimeoutException is thrown". For streaming this means that the exception is thrown if the first
-         * headers/bytes are not recieved within the timeout.
-         *
-         * The default value is null if the user does not set this timeout.
-         * @param timeout   A Duration representing the timeout.
-         * @return          The current Builder instance.
-         */
-        public Builder timeout(Duration timeout) {
-            this.timeout = timeout;
-            return this;
-        }
-
-        public StreamRequest build() {
-            return new StreamRequest(token, cursor, startTs, timeout);
-        }
-
+        gen.writeEndObject();
+        gen.flush();
+        return requestBytes.toString(StandardCharsets.UTF_8);
     }
 
-    /**
-     * Create a new StreamRequest.Builder instance.
-     * @param token The Fauna Stream token to use.
-     * @return  A new StreamRequest.Builder instance.
-     */
-    public static Builder builder(String token) {
-        return new Builder(token);
-    }
-
-    /**
-     * Stream token for the event stream to subscribe to.
-     * @return  A String representing the Stream token.
-     */
-    public String getToken() {
-        return token;
-    }
-
-    /**
-     * Cursor for a previous event. If provided, the stream replays any events that occurred after
-     * the cursor (exclusive).
-     * @return  The cursor, or Optional.empty() if not provided.
-     */
-    public Optional<String> getCursor() {
-        return Optional.ofNullable(cursor);
-    }
-
-    /**
-     * Stream start time in microseconds since the Unix epoch. This is typically a previous event's txn_ts
-     * (transaction timestamp).
-     * @return The stream start time, as a Long, or Optional.empty() if not provided.
-     */
-    public Optional<Long> getStartTs() {
-        return Optional.ofNullable(startTs);
-    }
-
-    /**
-     * Stream HTTP request timeout. This timeout is passed to java.net.http.HttpRequest.Builder. The default
-     * is null/empty.
-     * @return  The timeout Duration, or Optional.empty() if not set.
-     */
-    public Optional<Duration> getTimeout() {
-        return Optional.ofNullable(timeout);
-    }
 }

--- a/src/main/java/com/fauna/exception/ServiceException.java
+++ b/src/main/java/com/fauna/exception/ServiceException.java
@@ -90,7 +90,7 @@ public class ServiceException extends FaunaException {
      *
      * @return the schema version as a long value
      */
-    public long getSchemaVersion() {
+    public Long getSchemaVersion() {
         return this.response.getSchemaVersion();
     }
 

--- a/src/main/java/com/fauna/response/QueryFailure.java
+++ b/src/main/java/com/fauna/response/QueryFailure.java
@@ -27,7 +27,6 @@ public final class QueryFailure extends QueryResponse {
 
     public <T> Optional<T> getAbort(Class<T> clazz) {
         return errorInfo.getAbort(clazz);
-
     }
 
     public String getFullMessage() {

--- a/src/main/java/com/fauna/types/Page.java
+++ b/src/main/java/com/fauna/types/Page.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  *
  * @param <T> The type of data contained in the page.
  */
-public class Page<T>{
+public class Page<T> {
     private final List<T> data;
     private final String after;
 

--- a/src/test/java/com/fauna/beans/InventorySource.java
+++ b/src/test/java/com/fauna/beans/InventorySource.java
@@ -1,0 +1,10 @@
+package com.fauna.beans;
+
+import com.fauna.e2e.beans.Product;
+import com.fauna.event.EventSourceResponse;
+import com.fauna.types.Page;
+
+public class InventorySource {
+    public Page<Product> firstPage;
+    public EventSourceResponse eventSource;
+}

--- a/src/test/java/com/fauna/client/DefaultsTest.java
+++ b/src/test/java/com/fauna/client/DefaultsTest.java
@@ -3,6 +3,7 @@ package com.fauna.client;
 import com.fauna.codec.DefaultCodecProvider;
 import com.fauna.event.EventSource;
 import com.fauna.event.FeedOptions;
+import com.fauna.event.StreamOptions;
 import com.fauna.query.QueryOptions;
 import com.fauna.event.StreamRequest;
 import org.junit.jupiter.api.Test;
@@ -64,7 +65,7 @@ public class DefaultsTest {
         assertEquals(Duration.ofSeconds(10), feedRequest.timeout().orElseThrow());
 
         // We do not want a timeout set for stream requests, because the client may hold the stream open indefinitely.
-        HttpRequest streamRequest = streamRequestBuilder.buildStreamRequest(StreamRequest.builder("token").build());
+        HttpRequest streamRequest = streamRequestBuilder.buildStreamRequest(source, StreamOptions.builder().build());
         assertTrue(streamRequest.headers().firstValue(RequestBuilder.Headers.QUERY_TIMEOUT_MS).isEmpty());
         assertTrue(streamRequest.timeout().isEmpty());
 
@@ -85,7 +86,7 @@ public class DefaultsTest {
 
     @Test
     public void testOverridingTimeouts() {
-        HttpRequest streamRequest = streamRequestBuilder.buildStreamRequest(StreamRequest.builder("token").timeout(Duration.ofMinutes(10)).build());
+        HttpRequest streamRequest = streamRequestBuilder.buildStreamRequest(source, StreamOptions.builder().timeout(Duration.ofMinutes(10)).build());
         assertEquals(Duration.ofMinutes(10), streamRequest.timeout().orElseThrow());
     }
 

--- a/src/test/java/com/fauna/client/FeedIteratorTest.java
+++ b/src/test/java/com/fauna/client/FeedIteratorTest.java
@@ -55,7 +55,7 @@ public class FeedIteratorTest {
                 "cursor0", System.currentTimeMillis() - 5,
                 num + "-b", null, null));
 
-        return CompletableFuture.supplyAsync(() -> FeedPage.builder(codec, client.getStatsCollector()).events(events).cursor("cursor0").hasNext(after).build());
+        return CompletableFuture.supplyAsync(() -> FeedPage.builder(codec, new StatsCollectorImpl()).events(events).cursor("cursor0").hasNext(after).build());
     }
 
     private CompletableFuture<FeedPage<String>> failureFuture() throws IOException {
@@ -91,8 +91,7 @@ public class FeedIteratorTest {
 
     @Test
     public void test_multiple_pages() throws IOException {
-        when(client.poll(argThat(source::equals), argThat(FeedOptions.DEFAULT::equals), any(Class.class))).thenReturn(successFuture(true, 0));
-        when(client.poll(argThat(source::equals), argThat(opts -> opts.getCursor().orElse("").equals(CURSOR_0)), any(Class.class))).thenReturn(successFuture(false, 1));
+        when(client.poll(argThat(source::equals), any(), any(Class.class))).thenReturn(successFuture(true, 0), successFuture(false, 1));
         FeedIterator<String> feedIterator = new FeedIterator<>(client, source, FeedOptions.DEFAULT, String.class);
 
         assertTrue(feedIterator.hasNext());

--- a/src/test/java/com/fauna/client/FeedIteratorTest.java
+++ b/src/test/java/com/fauna/client/FeedIteratorTest.java
@@ -55,7 +55,7 @@ public class FeedIteratorTest {
                 "cursor0", System.currentTimeMillis() - 5,
                 num + "-b", null, null));
 
-        return CompletableFuture.supplyAsync(() -> FeedPage.builder(codec).events(events).cursor("cursor0").hasNext(after).build());
+        return CompletableFuture.supplyAsync(() -> FeedPage.builder(codec, client.getStatsCollector()).events(events).cursor("cursor0").hasNext(after).build());
     }
 
     private CompletableFuture<FeedPage<String>> failureFuture() throws IOException {

--- a/src/test/java/com/fauna/e2e/E2EStreamingTest.java
+++ b/src/test/java/com/fauna/e2e/E2EStreamingTest.java
@@ -117,7 +117,7 @@ public class E2EStreamingTest {
     public void query_streamOfProduct() throws InterruptedException {
         QueryStatsSummary initialStats = client.getStatsCollector().read();
         // Initialize stream outside try-with-resources so we can assert that it's closed at the end of this test;.
-        FaunaStream<Product> stream = client.stream(fql("Product.all().toStream()"), Product.class);
+        FaunaStream<Product> stream = client.stream(fql("Product.all().eventSource()"), Product.class);
         try (stream) {
             InventorySubscriber inventory = new InventorySubscriber();
             stream.subscribe(inventory);
@@ -156,7 +156,7 @@ public class E2EStreamingTest {
     public void handleStreamError() throws InterruptedException {
         // It would be nice to have another test that generates a stream with normal events, and then an error
         // event, but this at least tests some of the functionality.
-        QuerySuccess<EventSourceResponse> queryResp = client.query(fql("Product.all().toStream()"), EventSourceResponse.class);
+        QuerySuccess<EventSourceResponse> queryResp = client.query(fql("Product.all().eventSource()"), EventSourceResponse.class);
         EventSource source = EventSource.fromResponse(queryResp.getData());
         StreamOptions options = StreamOptions.builder().cursor("invalid_cursor").build();
         FaunaStream<Product> stream = client.stream(source, options, Product.class);
@@ -171,7 +171,7 @@ public class E2EStreamingTest {
 
     @Test
     public void handleStreamTimeout() {
-        QuerySuccess<EventSourceResponse> queryResp = client.query(fql("Product.all().toStream()"), EventSourceResponse.class);
+        QuerySuccess<EventSourceResponse> queryResp = client.query(fql("Product.all().eventSource()"), EventSourceResponse.class);
         EventSource source = EventSource.fromResponse(queryResp.getData());
         StreamOptions options = StreamOptions.builder().timeout(Duration.ofMillis(1)).build();
         ClientException exc = assertThrows(ClientException.class, () -> client.stream(source, options, Product.class));
@@ -185,7 +185,7 @@ public class E2EStreamingTest {
     @Test
     public void handleLargeEvents() throws InterruptedException {
         InventorySubscriber inventory;
-        try (FaunaStream<Product> stream = client.stream(fql("Product.all().toStream()"), Product.class)) {
+        try (FaunaStream<Product> stream = client.stream(fql("Product.all().eventSource()"), Product.class)) {
             inventory = new InventorySubscriber();
             stream.subscribe(inventory);
         }
@@ -233,7 +233,7 @@ public class E2EStreamingTest {
     @Disabled("This test sometimes causes Fauna to generate an error for getting too far behind.")
     @Test
     public void handleManyEvents() throws InterruptedException {
-        FaunaStream stream = client.stream(fql("Product.all().toStream()"), Product.class);
+        FaunaStream stream = client.stream(fql("Product.all().eventSource()"), Product.class);
         InventorySubscriber inventory = new InventorySubscriber();
 
         stream.subscribe(inventory);

--- a/src/test/java/com/fauna/e2e/E2EStreamingTest.java
+++ b/src/test/java/com/fauna/e2e/E2EStreamingTest.java
@@ -1,7 +1,9 @@
 package com.fauna.e2e;
 
+import com.fauna.beans.InventorySource;
 import com.fauna.client.Fauna;
 import com.fauna.client.FaunaClient;
+import com.fauna.client.PageIterator;
 import com.fauna.client.QueryStatsSummary;
 import com.fauna.event.EventSource;
 import com.fauna.event.FaunaStream;
@@ -9,9 +11,12 @@ import com.fauna.e2e.beans.Product;
 import com.fauna.event.StreamOptions;
 import com.fauna.exception.ClientException;
 import com.fauna.event.EventSourceResponse;
+import com.fauna.exception.NullDocumentException;
+import com.fauna.query.QueryOptions;
 import com.fauna.query.builder.Query;
 import com.fauna.response.QuerySuccess;
 import com.fauna.event.FaunaEvent;
+import com.fauna.types.NullableDocument;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -20,6 +25,7 @@ import java.net.http.HttpTimeoutException;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -32,6 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.fauna.codec.Generic.nullableDocumentOf;
 import static com.fauna.query.builder.Query.fql;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -59,13 +66,37 @@ public class E2EStreamingTest {
                 Map.of("name", randomName(5), "quantity", random.nextInt(1, 16)));
     }
 
+    public static void waitForSync(InventorySubscriber watcher) throws InterruptedException {
+        long start = System.currentTimeMillis();
+        int events = watcher.countEvents();
+        while (System.currentTimeMillis() < start + 2_000) {
+            Thread.sleep(10);
+            int latest = watcher.countEvents();
+            if (latest > events) {
+                events = latest;
+            }
+        }
+
+    }
+
+    private static Long doDelete(String name) {
+        Query query = fql("Product.firstWhere(.name == ${name})!.delete()", Map.of("name", name));
+        QuerySuccess<NullableDocument<Product>> success = client.query(query, nullableDocumentOf(Product.class));
+        NullableDocument<Product> nullDoc = success.getData();
+        assertThrows(NullDocumentException.class, () -> nullDoc.get());
+        return success.getLastSeenTxn();
+    }
 
     static class InventorySubscriber implements Flow.Subscriber<FaunaEvent<Product>> {
         private final AtomicLong timestamp = new AtomicLong(0);
         private String cursor = null;
         private final AtomicInteger events = new AtomicInteger(0);
-        Map<String, Integer> inventory = new ConcurrentHashMap<>();
+        private final Map<String, Integer> inventory;
         Flow.Subscription subscription;
+
+        public InventorySubscriber(Map<String, Integer> inventory) {
+            this.inventory = inventory;
+        }
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
@@ -75,9 +106,12 @@ public class E2EStreamingTest {
 
         @Override
         public void onNext(FaunaEvent<Product> event) {
-            System.out.println(MessageFormat.format("Event {0}, {1}", event.getCursor(), event.getTimestamp().orElse(-1L)));
             events.addAndGet(1);
-            event.getData().ifPresent(product -> inventory.put(product.getName(), product.getQuantity()));
+            if (event.getType().equals(FaunaEvent.EventType.ADD) || event.getType().equals(FaunaEvent.EventType.UPDATE)) {
+                event.getData().ifPresent(product -> inventory.put(product.getName(), product.getQuantity()));
+            } else if (event.getType().equals(FaunaEvent.EventType.REMOVE)) {
+                event.getData().ifPresent(product -> inventory.remove(product.getName()));
+            }
             // Fauna delivers events to the client in order, but it's up to the user to keep those events in order.
             event.getTimestamp().ifPresent(ts -> this.timestamp.updateAndGet(value -> value < ts ? value : ts));
             this.cursor = event.getCursor();
@@ -119,37 +153,68 @@ public class E2EStreamingTest {
         // Initialize stream outside try-with-resources so we can assert that it's closed at the end of this test;.
         FaunaStream<Product> stream = client.stream(fql("Product.all().eventSource()"), Product.class);
         try (stream) {
-            InventorySubscriber inventory = new InventorySubscriber();
-            stream.subscribe(inventory);
+            InventorySubscriber watcher = new InventorySubscriber(new ConcurrentHashMap<>());
+            stream.subscribe(watcher);
             assertFalse(stream.isClosed());
-            List<Product> products = new ArrayList<>();
-            products.add(client.query(fql("Product.create({name: 'cheese', quantity: 1})"), Product.class).getData());
+
+            doDelete("product-2");
+
+            waitForSync(watcher);
+            watcher.onComplete();
+            assertFalse(stream.isClosed());
+        }
+        stream.close();
+        assertTrue(stream.isClosed());
+    }
+
+    @Test
+    public void query_trackStateWithStream() throws InterruptedException {
+        // This test demonstrates querying the current state of a collection, and then tracking the changes from
+        // that moment on, which guarantees that no updates will be missed.
+        QueryStatsSummary initialStats = client.getStatsCollector().read();
+        QuerySuccess<InventorySource> success = client.query(fql("let products = Product.all()\n{ firstPage: products.pageSize(4), eventSource: products.eventSource()}"), InventorySource.class );
+        InventorySource inventorySource = success.getData();
+
+        // First, we process all the products that existed when the query was made.
+        PageIterator<Product> pageIterator = new PageIterator<>(client, inventorySource.firstPage, Product.class, QueryOptions.DEFAULT);
+        Map<String, Integer> inventory = new HashMap<>();
+        List<Product> products = new ArrayList<>();
+        pageIterator.flatten().forEachRemaining(product -> {
+            products.add(product); inventory.put(product.getName(), product.getQuantity());
+        });
+
+        // Now start a stream based on same query, and it's transaction timestamp.
+        EventSource eventSource = EventSource.fromResponse(inventorySource.eventSource);
+        StreamOptions streamOptions = StreamOptions.builder().startTimestamp(success.getLastSeenTxn()).build();
+        FaunaStream<Product> stream = client.stream(eventSource, streamOptions, Product.class);
+        try (stream) {
+            InventorySubscriber watcher = new InventorySubscriber(inventory);
+            stream.subscribe(watcher);
+            assertFalse(stream.isClosed());
             products.add(client.query(fql("Product.create({name: 'bread', quantity: 2})"), Product.class).getData());
-            products.add(client.query(fql("Product.create({name: 'wine', quantity: 3})"), Product.class).getData());
-            long start = System.currentTimeMillis();
-            int events = inventory.countEvents();
-            System.out.println("Events: " + events);
-            while (System.currentTimeMillis() < start + 2_000) {
-                Thread.sleep(10);
-                int latest = inventory.countEvents();
-                if (latest > events) {
-                    events = latest;
-                }
-            }
-            inventory.onComplete();
-            System.out.println(inventory.status());
+            products.add(client.query(fql("Product.firstWhere(.name == \"product-0\")!.update({quantity: 30})"), Product.class).getData());
+            waitForSync(watcher);
+            int before = watcher.countInventory();
+
+            client.query(fql("Product.create({name: 'cheese', quantity: 17})"), Product.class).getData();
+            waitForSync(watcher);
+            assertEquals(before + 17, watcher.countInventory());
+
+            doDelete("cheese");
+            waitForSync(watcher);
+            assertEquals(before, watcher.countInventory());
+
+            watcher.onComplete();
             Integer total = products.stream().map(Product::getQuantity).reduce(0, Integer::sum);
-            assertEquals(total, inventory.countInventory());
+            assertEquals(total, watcher.countInventory());
             assertFalse(stream.isClosed());
         }
         stream.close();
         assertTrue(stream.isClosed());
 
         QueryStatsSummary finalStats = client.getStatsCollector().read();
-        assertEquals(11, finalStats.getReadOps() - initialStats.getReadOps());
-        assertEquals(8, finalStats.getComputeOps() - initialStats.getComputeOps());
-        assertEquals(8, finalStats.getQueryCount() - initialStats.getQueryCount());
-
+        assertTrue(finalStats.getReadOps() > initialStats.getReadOps());
+        assertTrue(finalStats.getComputeOps() > initialStats.getComputeOps());
     }
 
     @Test
@@ -160,7 +225,7 @@ public class E2EStreamingTest {
         EventSource source = EventSource.fromResponse(queryResp.getData());
         StreamOptions options = StreamOptions.builder().cursor("invalid_cursor").build();
         FaunaStream<Product> stream = client.stream(source, options, Product.class);
-        InventorySubscriber inventory = new InventorySubscriber();
+        InventorySubscriber inventory = new InventorySubscriber(new ConcurrentHashMap<>());
         stream.subscribe(inventory);
         long start = System.currentTimeMillis();
         while (!stream.isClosed() && System.currentTimeMillis() < (start + 5_000)) {
@@ -177,8 +242,6 @@ public class E2EStreamingTest {
         ClientException exc = assertThrows(ClientException.class, () -> client.stream(source, options, Product.class));
         assertEquals(ExecutionException.class, exc.getCause().getClass());
         assertEquals(HttpTimeoutException.class, exc.getCause().getCause().getClass());
-
-
     }
 
     @Disabled("Will fix this for GA, I think the other drivers have this bug too.")
@@ -186,7 +249,7 @@ public class E2EStreamingTest {
     public void handleLargeEvents() throws InterruptedException {
         InventorySubscriber inventory;
         try (FaunaStream<Product> stream = client.stream(fql("Product.all().eventSource()"), Product.class)) {
-            inventory = new InventorySubscriber();
+            inventory = new InventorySubscriber(new ConcurrentHashMap<>());
             stream.subscribe(inventory);
         }
         List<Product> products = new ArrayList<>();
@@ -234,7 +297,7 @@ public class E2EStreamingTest {
     @Test
     public void handleManyEvents() throws InterruptedException {
         FaunaStream stream = client.stream(fql("Product.all().eventSource()"), Product.class);
-        InventorySubscriber inventory = new InventorySubscriber();
+        InventorySubscriber inventory = new InventorySubscriber(new ConcurrentHashMap<>());
 
         stream.subscribe(inventory);
         List<CompletableFuture<Product>> productFutures = new ArrayList<>();

--- a/src/test/java/com/fauna/stream/StreamRequestTest.java
+++ b/src/test/java/com/fauna/stream/StreamRequestTest.java
@@ -2,44 +2,42 @@ package com.fauna.stream;
 
 import com.fauna.codec.CodecProvider;
 import com.fauna.codec.DefaultCodecProvider;
+import com.fauna.event.EventSource;
+import com.fauna.event.StreamOptions;
 import com.fauna.event.StreamRequest;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StreamRequestTest {
     public static final CodecProvider provider = DefaultCodecProvider.SINGLETON;
+    private final static EventSource SOURCE = new EventSource("abc");
 
     @Test
-    public void testTokenOnlyRequest() {
-        StreamRequest req = StreamRequest.builder("abc").build();
-        assertEquals("abc", req.getToken());
-        assertTrue(req.getCursor().isEmpty());
-        assertTrue(req.getStartTs().isEmpty());
+    public void testTokenOnlyRequest() throws IOException {
+        StreamRequest req = new StreamRequest(SOURCE, StreamOptions.DEFAULT);
+        assertEquals("{\"token\":\"abc\"}", req.serialize());
     }
 
     @Test
-    public void testCursorRequest() {
-        StreamRequest req = StreamRequest.builder("abc").cursor("def").build();
-        assertEquals("abc", req.getToken());
-        assertEquals("def", req.getCursor().get());
-        assertTrue(req.getStartTs().isEmpty());
+    public void testCursorRequest() throws IOException {
+        StreamRequest req = new StreamRequest(SOURCE, StreamOptions.builder().cursor("def").build());
+        assertEquals("{\"token\":\"abc\",\"cursor\":\"def\"}", req.serialize());
     }
 
     @Test
-    public void testTsRequest() {
-        StreamRequest req = StreamRequest.builder("abc").startTs(1234L).build();
-        assertEquals("abc", req.getToken());
-        assertTrue(req.getCursor().isEmpty());
-        assertEquals(1234L, req.getStartTs().get());
+    public void testTsRequest() throws IOException {
+        StreamRequest req = new StreamRequest(SOURCE, StreamOptions.builder().startTimestamp(1234L).build());
+        assertEquals("{\"token\":\"abc\",\"start_ts\":1234}", req.serialize());
     }
 
     @Test
-    public void testCursorAndTsRequest() {
-        assertThrows(IllegalArgumentException.class, () -> StreamRequest.builder("tkn").startTs(10L).cursor("hello"));
-        assertThrows(IllegalArgumentException.class, () -> StreamRequest.builder("tkn").cursor("hello").startTs(10L));
+    public void testMissingArgsRequest() {
+        assertThrows(IllegalArgumentException.class, () -> new StreamRequest(SOURCE, null));
+        assertThrows(IllegalArgumentException.class, () -> new StreamRequest(null, StreamOptions.DEFAULT));
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
1. User-facing Stream API now takes an `EventSource`, and `StreamOptions` instead of `StreamRequest`.
2. Replace usages of `toStream()` with `eventSource()`.
3. Add a new constructor to `PageIterator` that makes it possible to initialize with an existing page.
4. Ensure the `statsCollector` gets updated for feed page responses, (Leftover from PR #162)

Still TODO are README updates, final checks of test coverage, bug bash? etc.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
It's worth aligning the user-facing APIs before we GA the driver.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The unit and integ tests are fairly comprehensive, I also discovered a few things while building a sample app (how to do deletes, and the PageIterator gap).

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.