### PR TITLE
[DOCS-3726] Replace `EventSourceResponse` with `EventSource`

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ import com.fauna.event.FeedIterator;
 import com.fauna.event.EventSource;
 import com.fauna.event.FeedOptions;
 import com.fauna.event.FeedPage;
-import com.fauna.event.EventSourceResponse;
+import com.fauna.event.EventSource;
 import com.fauna.response.QuerySuccess;
 import com.fauna.event.FaunaEvent;
 
@@ -563,9 +563,9 @@ public class EventFeedExample {
         }
 
         // Example 4: Using `poll()`
-        QuerySuccess<EventSourceResponse> sourceQuery = client.query(
+        QuerySuccess<EventSource> sourceQuery = client.query(
             fql("Product.all().eventSource()"),
-            EventSourceResponse.class
+            EventSource.class
         );
         EventSource source = EventSource.fromResponse(sourceQuery.getData());
 
@@ -639,9 +639,9 @@ CompletableFuture<FeedIterator<Product>> iteratorFuture = client.asyncFeed(
 );
 
 // Example 3: Using `poll()`
-QuerySuccess<EventSourceResponse> sourceQuery = client.query(
+QuerySuccess<EventSource> sourceQuery = client.query(
     query,
-    EventSourceResponse.class
+    EventSource.class
 );
 EventSource source = EventSource.fromResponse(sourceQuery.getData());
 
@@ -682,9 +682,9 @@ CompletableFuture<FeedIterator<Product>> iteratorFuture = client.asyncFeed(
 );
 
 // Example 3: Using `poll()`
-QuerySuccess<EventSourceResponse> sourceQuery = client.query(
+QuerySuccess<EventSource> sourceQuery = client.query(
     query,
-    EventSourceResponse.class
+    EventSource.class
 );
 EventSource source = EventSource.fromResponse(sourceQuery.getData());
 
@@ -752,7 +752,7 @@ To start and subscribe to the stream, pass an `EventSource` and related
 ```java
 // Get an event source.
 Query query = fql("Product.all().eventSource() { name, stock }");
-QuerySuccess<EventSourceResponse> tokenResponse = client.query(query, EventSourceResponse.class);
+QuerySuccess<EventSource> tokenResponse = client.query(query, EventSource.class);
 EventSource eventSource = EventSource.fromResponse(querySuccess.getData());
 
 // Calculate the timestamp for 10 minutes ago in microseconds.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
Replaces the `EventSourceResponse` class with `EventSource` in the README. The`EventSourceResponse` class was removed with https://github.com/fauna/fauna-jvm/pull/184.

### Motivation and context
Keep the docs up-to-date.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.