### PR TITLE
docs: Fix typo in javadocs

### DIFF
--- a/src/main/java/com/fauna/exception/NullDocumentException.java
+++ b/src/main/java/com/fauna/exception/NullDocumentException.java
@@ -3,7 +3,7 @@ package com.fauna.exception;
 import com.fauna.types.Module;
 
 /**
- * Exception representing a <a href="https://docs.fauna.com/fauna/current/reference/fql/types/#nulldoc"≥null document</a> error in Fauna.
+ * Exception representing a <a href="https://docs.fauna.com/fauna/current/reference/fql/types/#nulldoc">null document</a> error in Fauna.
  * <p>
  * This exception is thrown when a document is null in Fauna, providing details about
  * the document ID, its collection, and the reason it is null.


### PR DESCRIPTION
### Description
Fixes a typo in the javadocs. I'll manually update the affected page once this is merged.

### Motivation and context
- Improve the docs.
- Stop a related javadoc warning

### How was the change tested?
`./gradlew javadoc`

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.