### PR TITLE
chore(perf-tests): A few minor tweaks to perf tests

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -86,7 +86,7 @@ resources:
   - name: dev-tests-trigger
     type: time
     source:
-      interval: 6h
+      interval: 24h
 
 jobs:
   - name: set-self

--- a/concourse/scripts/perf.sh
+++ b/concourse/scripts/perf.sh
@@ -8,7 +8,7 @@ export LOG_UNIQUE=$(date +%s%3N)
 # Install fauna-shell
 apt update -qq
 apt install -y -qq npm
-npm install --silent -g fauna-shell@^2.0.0
+npm install --silent -g fauna-shell@^3.0.0
 
 cd repo.git
 

--- a/src/test/java/com/fauna/e2e/E2EFeedsTest.java
+++ b/src/test/java/com/fauna/e2e/E2EFeedsTest.java
@@ -12,6 +12,7 @@ import com.fauna.event.FeedPage;
 import com.fauna.exception.InvalidRequestException;
 import com.fauna.response.QueryFailure;
 import com.fauna.response.QuerySuccess;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -104,7 +105,7 @@ public class E2EFeedsTest {
         assertEquals(50, productUpdates.size());
         assertEquals(25, pageCount);
 
-        client.query(fql("Product.create({name:\"newProduct\",quantity:1})"),
+        client.query(fql("Product.create({name:\"newProduct\",quantity:123})"),
             Product.class);
 
         FeedOptions newOptions =
@@ -114,7 +115,11 @@ public class E2EFeedsTest {
         FeedPage<Product> newPageFuture =
             client.poll(source, newOptions, Product.class).join();
 
-        assertEquals(1, newPageFuture.getEvents().size());
+        List<FaunaEvent<Product>> newEvents = newPageFuture.getEvents();
+
+        assertEquals(1, newEvents.size());
+        assertEquals("newProduct", newEvents.get(0).getData().get().getName());
+        assertEquals(123, newEvents.get(0).getData().get().getQuantity());
     }
 
     @Test

--- a/src/test/java/com/fauna/e2e/E2EFeedsTest.java
+++ b/src/test/java/com/fauna/e2e/E2EFeedsTest.java
@@ -14,6 +14,7 @@ import com.fauna.response.QueryFailure;
 import com.fauna.response.QuerySuccess;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -47,6 +48,10 @@ public class E2EFeedsTest {
         FaunaConfig config =
                 FaunaConfig.builder().endpoint(LOCAL).secret("secret").build();
         client = Fauna.client(config);
+    }
+
+    @BeforeEach
+    public void setupEach() {
         productCollectionTs = Fixtures.ProductCollection(client);
     }
 

--- a/src/test/java/com/fauna/e2e/E2EFeedsTest.java
+++ b/src/test/java/com/fauna/e2e/E2EFeedsTest.java
@@ -105,8 +105,7 @@ public class E2EFeedsTest {
         assertEquals(50, productUpdates.size());
         assertEquals(25, pageCount);
 
-        client.query(fql("Product.create({name:\"newProduct\",quantity:123})"),
-            Product.class);
+        client.query(fql("Product.create({name:\"newProduct\",quantity:123})"));
 
         FeedOptions newOptions =
             FeedOptions.builder().cursor(lastPageCursor).pageSize(2)

--- a/src/test/java/com/fauna/e2e/E2EFeedsTest.java
+++ b/src/test/java/com/fauna/e2e/E2EFeedsTest.java
@@ -85,6 +85,7 @@ public class E2EFeedsTest {
             // Handle page
             FeedPage<Product> latestPage = pageFuture.join();
             lastPageCursor = latestPage.getCursor();
+            System.out.println(lastPageCursor);
             productUpdates.addAll(latestPage.getEvents());
             pageCount++;
 
@@ -100,11 +101,6 @@ public class E2EFeedsTest {
         }
         assertEquals(50, productUpdates.size());
         assertEquals(25, pageCount);
-        // Because there is no filtering, these cursors are the same.
-        // If we filtered events, then the page cursor could be different from the cursor of the last element.
-        assertEquals(lastPageCursor,
-                productUpdates.get(productUpdates.size() - 1).getCursor());
-
     }
 
     @Test

--- a/src/test/java/com/fauna/perf/PerformanceTest.java
+++ b/src/test/java/com/fauna/perf/PerformanceTest.java
@@ -32,8 +32,9 @@ public class PerformanceTest {
     }
 
     @BeforeAll
-    public static void setup() {
+    public static void setup() throws IllegalArgumentException, InterruptedException, ExecutionException {
         client = Fauna.client();
+        client.asyncQuery(fql("null")).get();
     }
 
     @AfterAll

--- a/src/test/java/com/fauna/perf/PerformanceTest.java
+++ b/src/test/java/com/fauna/perf/PerformanceTest.java
@@ -34,6 +34,8 @@ public class PerformanceTest {
     @BeforeAll
     public static void setup() throws IllegalArgumentException, InterruptedException, ExecutionException {
         client = Fauna.client();
+
+        // Throw away results of initial query used just for establishing connection
         client.asyncQuery(fql("null")).get();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
This PR updates the perf tests with a few needed tweaks:
- Reduce frequency in the pipeline to 1/day
- Add a preliminary query in `BeforeAll` method to throw out initial connection
- Bring in latest `driver-perf-utils` commit and use CLI v3

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub or Jira issue, link to the issue. -->
Improving high percentile perf numbers

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cribbed from change that's live in `fauna-dotnet`

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)
* - [x] Test only change

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.